### PR TITLE
Self documentation based on AA+.htm doc

### DIFF
--- a/Src/AASharp/AAS2DCoordinate.cs
+++ b/Src/AASharp/AAS2DCoordinate.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// 2D coordinates used by many of the AASharp methods.
+    /// </summary>
     public class AAS2DCoordinate
     {
         public double X { get; set; }

--- a/Src/AASharp/AAS3DCoordinate.cs
+++ b/Src/AASharp/AAS3DCoordinate.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// 3D rectangular coordinates used by many of the AASharp methods.
+    /// </summary>
     public class AAS3DCoordinate
     {
         public double X { get; set; }

--- a/Src/AASharp/AASAberration.cs
+++ b/Src/AASharp/AASAberration.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the effects of aberration. This refers to Chapter 23 in the book.
+    /// </summary>
     public static class AASAberration
     {
         #region coefficients
@@ -48,7 +51,10 @@ namespace AASharp
         };
 
         #endregion
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>3D rectangular heliocentric equatorial velocity of the Earth based on the fixed equator and equinox of FK5 for the epoch J2000.0. The units of each coordinate returned are in 10 to the power of -8 astronomical units per day.</returns>
         public static AAS3DCoordinate EarthVelocity(double JD, bool bHighPrecision)
         {
             AAS3DCoordinate velocity = new AAS3DCoordinate();
@@ -102,6 +108,11 @@ namespace AASharp
             return velocity;
         }
 
+        /// <param name="Alpha">The right ascension expressed as an hour angle.</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>Returns the correction due to aberration. The X value will contain the right ascension correction expressed as an hour angle and Y will contain the declination correction in degrees.</returns>
         public static AAS2DCoordinate EquatorialAberration(double Alpha, double Delta, double JD, bool bHighPrecision)
         {
             //Convert to radians
@@ -121,6 +132,11 @@ namespace AASharp
             return aberration;
         }
 
+        /// <param name="Lambda">The ecliptic longitude in degrees.</param>
+        /// <param name="Beta">The ecliptic latitude in degrees.</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>Returns the correction due to aberration. The X value will contain the ecliptic longitude correction in degrees and Y will contain the ecliptic latitude correction in degrees.</returns>
         public static AAS2DCoordinate EclipticAberration(double Lambda, double Beta, double JD, bool bHighPrecision)
         {
             //What is the return value

--- a/Src/AASharp/AASAngularSeparation.cs
+++ b/Src/AASharp/AASAngularSeparation.cs
@@ -2,8 +2,16 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms which obtain various separation distances between celestial objects. This refers to Chapter 17, 19 &amp; 20 in the book.
+    /// </summary>
     public static class AASAngularSeparation
     {
+        /// <param name="Alpha1">The first right ascension expressed as an hour angle.</param>
+        /// <param name="Delta1">The first declination in degrees</param>
+        /// <param name="Alpha2">The second right ascension expressed as an hour angle.</param>
+        /// <param name="Delta2">The second declination in degrees</param>
+        /// <returns>Returns the distance between the two positions in degrees.</returns>
         public static double Separation(double Alpha1, double Delta1, double Alpha2, double Delta2)
         {
             Delta1 = AASCoordinateTransformation.DegreesToRadians(Delta1);
@@ -24,6 +32,11 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Alpha1">The first right ascension expressed as an hour angle.</param>
+        /// <param name="Delta1">The first declination in degrees</param>
+        /// <param name="Alpha2">The second right ascension expressed as an hour angle.</param>
+        /// <param name="Delta2">The second declination in degrees</param>
+        /// <returns>Returns the position angle of (Alpha1, Delta1) relative to (Alpha2, Delta2) in degrees.</returns>
         public static double PositionAngle(double Alpha1, double Delta1, double Alpha2, double Delta2)
         {
             Delta1 = AASCoordinateTransformation.DegreesToRadians(Delta1);
@@ -41,6 +54,13 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Alpha1">The first right ascension expressed as an hour angle.</param>
+        /// <param name="Delta1">The first declination in degrees</param>
+        /// <param name="Alpha2">The second right ascension expressed as an hour angle.</param>
+        /// <param name="Delta2">The second declination in degrees</param>
+        /// <param name="Alpha3">The third right ascension expressed as an hour angle.</param>
+        /// <param name="Delta3">The third declination in degrees</param>
+        /// <returns>Returns the distance of (Alpha3, Delta3) to the great circle (Alpha1, Delta1) - (Alpha2, Delta2) in degrees.</returns>
         public static double DistanceFromGreatArc(double Alpha1, double Delta1, double Alpha2, double Delta2, double Alpha3, double Delta3)
         {
             Delta1 = AASCoordinateTransformation.DegreesToRadians(Delta1);
@@ -75,6 +95,14 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Alpha1">The first right ascension expressed as an hour angle.</param>
+        /// <param name="Delta1">The first declination in degrees</param>
+        /// <param name="Alpha2">The second right ascension expressed as an hour angle.</param>
+        /// <param name="Delta2">The second declination in degrees</param>
+        /// <param name="Alpha3">The third right ascension expressed as an hour angle.</param>
+        /// <param name="Delta3">The third declination in degrees</param>
+        /// <param name="bType1">Upon return will be true if the smallest circle is of type 1, otherwise false, implying smallest circle is of type 2.</param>
+        /// <returns>Returns the diameter of the smallest circle encompassing the 3 points in degrees.</returns>
         public static double SmallestCircle(double Alpha1, double Delta1, double Alpha2, double Delta2, double Alpha3, double Delta3, ref bool bType1)
         {
             double d1 = Separation(Alpha1, Delta1, Alpha2, Delta2);

--- a/Src/AASharp/AASBinaryStar.cs
+++ b/Src/AASharp/AASBinaryStar.cs
@@ -2,8 +2,36 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the position of a Binary Star system. This refers to Chapter 57 in the book.
+    /// </summary>
     public static class AASBinaryStar
     {
+        /// <param name="t">The time given in years and decimals to perform the calculation for.</param>
+        /// <param name="P">The period of revolution expressed in mean solar years.</param>
+        /// <param name="T">The time of periastron passage given in years and decimals.</param>
+        /// <param name="e">Eccentricity of the true orbit.</param>
+        /// <param name="a">The semi major axis expressed in seconds of a degree.</param>
+        /// <param name="i">The inclination of the plane of the true orbit in degrees to the plane at right angles to the line of sight.</param>
+        /// <param name="omega">The position angle of the ascending node in degrees.</param>
+        /// <param name="w">The longitude of the periastron in degrees.</param>
+        /// <returns>A class containing
+        /// <para>
+        /// r - The radius vector of the secondary star in arc seconds of a degree.
+        /// </para>
+        /// <para>
+        /// Theta - The apparent position angle of the secondary star in degrees.
+        /// </para>
+        /// <para>
+        /// Rho - The angular separation between the two stars in arc seconds of a degree.
+        /// </para>
+        /// <para>
+        /// x - The x cartesian coordinate value of the secondary star in arc seconds of a degree.
+        /// </para>
+        /// <para>
+        /// y - The y cartesian coordinate value of the secondary star in arc seconds of a degree.
+        /// </para>
+        /// </returns>
         public static AASBinaryStarDetails Calculate(double t, double P, double T, double e, double a, double i, double omega, double w)
         {
             double n = 360 / P;
@@ -28,6 +56,10 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="e">Eccentricity of the true orbit.</param>
+        /// <param name="i">The inclination of the plane of the true orbit in degrees to the plane at right angles to the line of sight.</param>
+        /// <param name="w">The longitude of the periastron in degrees.</param>
+        /// <returns>The apparent eccentricity of the binary star orbit</returns>
         public static double ApparentEccentricity(double e, double i, double w)
         {
             i = AASCoordinateTransformation.DegreesToRadians(i);

--- a/Src/AASharp/AASBinaryStarDetails.cs
+++ b/Src/AASharp/AASBinaryStarDetails.cs
@@ -1,9 +1,21 @@
 namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASBinaryStar.Calculate method.
+    /// </summary>
     public class AASBinaryStarDetails
     {
+        /// <summary>
+        /// The radius vector of the secondary star in arc seconds of a degree.
+        /// </summary>
         public double r { get; set; }
+        /// <summary>
+        /// The angular separation between the two stars in arc seconds of a degree.
+        /// </summary>
         public double Rho { get; set; }
+        /// <summary>
+        /// The apparent position angle of the secondary star in degrees.
+        /// </summary>
         public double Theta { get; set; }
     }
 }

--- a/Src/AASharp/AASCalendarDate.cs
+++ b/Src/AASharp/AASCalendarDate.cs
@@ -1,9 +1,21 @@
 namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASDate.JulianToGregorian and AASDate.GregorianToJulian methods.
+    /// </summary>
     public class AASCalendarDate
     {
+        /// <summary>
+        /// The year in the Gregorian/Julian Calendar. (Years are counted astronomically i.e. 1 BC = Year 0)
+        /// </summary>
         public long Year { get; set; }
+        /// <summary>
+        /// The month of the year in the Gregorian/Julian Calendar (1 for January to 12 for December).
+        /// </summary>
         public long Month { get; set; }
+        /// <summary>
+        /// The day of the month in the Gregorian/Julian Calendar.
+        /// </summary>
         public long Day { get; set; }
     }
 }

--- a/Src/AASharp/AASCoordinateTransformation.cs
+++ b/Src/AASharp/AASCoordinateTransformation.cs
@@ -2,8 +2,18 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for the transformations of the coordinates as well as helper angle methods. This refers to Chapter 13 and parts of Chapter 1 in the book.
+    /// </summary>
     public static class AASCoordinateTransformation
     {
+        /// <summary>
+        /// The transformation of coordinates from Equatorial to Ecliptic. This refers to algorithm 13.1 and 13.2 on page 93.
+        /// </summary>
+        /// <param name="Alpha">The right ascension expressed as decimal hours.</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <param name="Epsilon">The obliquity of the ecliptic in degrees.</param>
+        /// <returns>Returns the converted ecliptic coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the ecliptic longitude in degrees and the y value corresponds to the ecliptic latitude in degrees.</returns>
         public static AAS2DCoordinate Equatorial2Ecliptic(double Alpha, double Delta, double Epsilon)
         {
             Alpha = HoursToRadians(Alpha);
@@ -18,6 +28,13 @@ namespace AASharp
             return Ecliptic;
         }
 
+        /// <summary>
+        /// The transformation of coordinates from Ecliptic to Equatorial. This refers to algorithm 13.3 and 13.4 on page 93.
+        /// </summary>
+        /// <param name="Lambda">The ecliptic longitude in degrees.</param>
+        /// <param name="Beta">The ecliptic latitude in degrees.</param>
+        /// <param name="Epsilon">The obliquity of the ecliptic in degrees.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the right ascension in decimal hours and the y value corresponds to the declination in degrees.</returns>
         public static AAS2DCoordinate Ecliptic2Equatorial(double Lambda, double Beta, double Epsilon)
         {
             Lambda = DegreesToRadians(Lambda);
@@ -32,6 +49,13 @@ namespace AASharp
             return Equatorial;
         }
 
+        /// <summary>
+        /// The transformation of coordinates from Equatorial to Horizontal. This refers to algorithm 13.5 and 13.6 on page 93.
+        /// </summary>
+        /// <param name="LocalHourAngle">The local hour angle in decimal hours, measured westwards from the South. To convert a equatorial right ascension to a local hour angle you can use the formula as mentioned on page 92: Local hour angle (H) = apparent sidereal time at Greenwich (theta) - observer's longitude (L, positive west, negative east from Greenwich) - right ascension. You should of course make sure that all the values used in this formula are expressed as decimal hours before applying the formula (in particular the observer's longitude "L" value).</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <param name="Latitude">The standard latitude of the position in degrees.</param>
+        /// <returns>Returns the converted horizontal coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the azimuth in degrees west of south and the y value corresponds to the altitude in degrees.</returns>
         public static AAS2DCoordinate Equatorial2Horizontal(double LocalHourAngle, double Delta, double Latitude)
         {
             LocalHourAngle = HoursToRadians(LocalHourAngle);
@@ -46,6 +70,13 @@ namespace AASharp
             return Horizontal;
         }
 
+        /// <summary>
+        /// The transformation of coordinates from Horizontal to Equatorial. This refers to the two algorithms on the top of page 94. To convert the returned local hour angle back to a right ascension in decimal hours you can use the formula as mentioned on page 92: right ascension (alpha) = apparent sidereal time at Greenwich (theta) - Local hour angle (H) - observer's longitude (L, positive west, negative east from Greenwich). You should of course make sure that all the values used in this formula are expressed as decimal hours before applying the formula (in particular the observer's longitude "L" value).
+        /// </summary>
+        /// <param name="Azimuth">The azimuth in degrees west of south.</param>
+        /// <param name="Altitude">The altitude in degrees</param>
+        /// <param name="Latitude">The standard latitude of the position in degrees.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the local hour angle in decimal hours and the y value corresponds to the declination in degrees.</returns>
         public static AAS2DCoordinate Horizontal2Equatorial(double Azimuth, double Altitude, double Latitude)
         {
             //Convert from degress to radians
@@ -61,6 +92,12 @@ namespace AASharp
             return Equatorial;
         }
 
+        /// <summary>
+        /// The transformation of coordinates from Equatorial to Galactic. This refers to algorithm 13.7 and 13.8 on page 94.
+        /// </summary>
+        /// <param name="Alpha">The right ascension in decimal hours.</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <returns>Returns the converted galactic coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the galactic longitude in degrees and the y value corresponds to the galactic latitude in degrees.</returns>
         public static AAS2DCoordinate Equatorial2Galactic(double Alpha, double Delta)
         {
             Alpha = 192.25 - HoursToDegrees(Alpha);
@@ -76,6 +113,12 @@ namespace AASharp
             return Galactic;
         }
 
+        /// <summary>
+        /// The transformation of coordinates from Galactic to Equatorial. This refers to the last two algorithms on page 94.
+        /// </summary>
+        /// <param name="l">The galactic longitude expressed in degrees.</param>
+        /// <param name="b">The galactic latitude expressed in degrees.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the right ascension in decimal hours and the y value corresponds to the declination in degrees.</returns>
         public static AAS2DCoordinate Galactic2Equatorial(double l, double b)
         {
             l -= 123;
@@ -92,7 +135,17 @@ namespace AASharp
             return Equatorial;
         }
 
-
+        /// <summary>
+        /// To convert the angle 21° 44' 07" you would use DMSToDegrees(21, 44, 7, true).
+        /// To convert the angle -12° 47' 22" you would use DMSToDegrees(12, 47, 22, false) or DMSToDegrees(-12, -47, -22, true).
+        /// To convert the angle -0° 32' 41" you must use DMSToDegrees(0, 32, 41, false).
+        /// </summary>
+        /// <param name="Degrees">The degree part of the angular value to convert.</param>
+        /// <param name="Minutes">The minute part of the angular value to convert.</param>
+        /// <param name="Seconds">The second part of the angular value to convert.</param>
+        /// <param name="bPositive">true if the input value corresponds to a non-negative value with false implying the value is positive</param>
+        /// <returns>Returns the value in degrees which was converted from degrees, minutes and seconds.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static double DMSToDegrees(double Degrees, double Minutes, double Seconds, bool bPositive = true)
         {
             //validate our parameters
@@ -112,41 +165,56 @@ namespace AASharp
                 return -Degrees - Minutes / 60 - Seconds / 3600;
         }
 
+        /// <param name="Degrees">The angular value to convert measured in degrees.</param>
+        /// <returns>Returns the value in radians which was converted from degrees.</returns>
         public static double DegreesToRadians(double Degrees)
         {
             return Degrees * 0.017453292519943295769236907684886;
         }
 
+        /// <param name="Radians">The angular value to convert measured in radians.</param>
+        /// <returns>Returns the value in degrees which was converted from radians.</returns>
         public static double RadiansToDegrees(double Radians)
         {
             return Radians * 57.295779513082320876798154814105;
         }
 
+        /// <param name="Radians">The angular value to convert measured in radians.</param>
+        /// <returns>Returns the value expressed as an hour angle which was converted from radians.</returns>
         public static double RadiansToHours(double Radians)
         {
             return Radians * 3.8197186342054880584532103209403;
         }
 
+        /// <param name="Hours">The numeric value to convert measured in hours.</param>
+        /// <returns>Returns the value in radians which was converted from hours.</returns>
         public static double HoursToRadians(double Hours)
         {
             return Hours * 0.26179938779914943653855361527329;
         }
 
+        /// <param name="Hours">The numeric value to convert measured in hours.</param>
+        /// <returns>Returns the value in degrees which was converted from hours.</returns>
         public static double HoursToDegrees(double Hours)
         {
             return Hours * 15;
         }
 
+        /// <param name="Degrees">The angular value to convert measured in degrees.</param>
+        /// <returns>Returns the value in hours which was converted from degrees.</returns>
         public static double DegreesToHours(double Degrees)
         {
             return Degrees / 15;
         }
 
+        /// <returns>Returns the constant value of pi i.e 3.1415926...</returns>
         public static double PI()
         {
             return 3.1415926535897932384626433832795;
         }
 
+        /// <param name="Degrees">The angular value.</param>
+        /// <returns>Maps an arbitrary angular value to the range 0 to 360. i.e. inputting the value -2 will return a value of 258.</returns>
         public static double MapTo0To360Range(double Degrees)
         {
             double fResult = Math.IEEERemainder(Degrees, 360);
@@ -158,7 +226,9 @@ namespace AASharp
             
             return fResult;
         }
-        
+
+        /// <param name="Degrees">The angular value.</param>
+        /// <returns>Maps an arbitrary angular value to the range -90 to 90.</returns>
         public static double MapToMinus90To90Range(double Degrees)
         {
             double fResult = MapTo0To360Range(Degrees);
@@ -179,6 +249,8 @@ namespace AASharp
             return fResult;
         }
 
+        /// <param name="HourAngle">The hour angle.</param>
+        /// <returns>Maps an arbitrary value to the range 0 to 24. i.e. inputting the value -2 will return a value of 22.</returns>
         public static double MapTo0To24Range(double HourAngle)
         {
             double fResult = Math.IEEERemainder(HourAngle, 24);
@@ -190,8 +262,9 @@ namespace AASharp
             
             return fResult;
         }
-        
-        
+
+        /// <param name="Angle">The angle in radians.</param>
+        /// <returns>Maps an arbitrary value to the range 0 to 2*PI. i.e. inputting the value -1 will return a value of 5.2831853071795862.</returns>
         public static double MapTo0To2PIRange(double Angle)
         {
             double fResult = Math.IEEERemainder(Angle, 2 * PI());

--- a/Src/AASharp/AASDate.cs
+++ b/Src/AASharp/AASDate.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms which convert between the Gregorian and Julian calendars and the Julian Day. This refers to Chapter 7 and parts of Chapter 9 in the book.
+    /// </summary>
     public class AASDate
     {
         #region constructors
@@ -10,25 +13,54 @@ namespace AASharp
         {
         }
 
+        /// <summary>
+        /// Constructs a date given a variety of parameters.
+        /// </summary>
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month (Can include decimals).</param>
+        /// <param name="bGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
         public AASDate(long year, long month, double day, bool bGregorianCalendar)
         {
             Set(year, month, day, 0, 0, 0, bGregorianCalendar);
         }
 
+        /// <summary>
+        /// Constructs a date given a variety of parameters.
+        /// </summary>
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month (Can include decimals).</param>
+        /// <param name="hour">The hour (Can include decimals).</param>
+        /// <param name="minute">The minute (Can include decimals).</param>
+        /// <param name="second">The seconds (Can include decimals).</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
         public AASDate(long year, long month, double day, double hour, double minute, double second, bool isGregorianCalendar)
         {
             Set(year, month, day, hour, minute, second, isGregorianCalendar);
         }
 
+        /// <summary>
+        /// Constructs a date given a variety of parameters.
+        /// </summary>
+        /// <param name="JD">The Julian day including decimals.</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
         public AASDate(double JD, bool isGregorianCalendar)
         {
             Set(JD, isGregorianCalendar);
         }
-        
+
         #endregion
 
         #region static members
-
+        /// <summary>
+        /// Converts a calendar date to Julian day.
+        /// </summary>
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month (Can include decimals).</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
+        /// <returns>Returns Julian Day including decimals.</returns>
         public static double DateToJD(long year, long month, double day, bool isGregorianCalendar)
         {
             long Y = year;
@@ -49,6 +81,9 @@ namespace AASharp
             return INT(365.25 * (Y + 4716)) + INT(30.6001 * (M + 1)) + day + B - 1524.5;
         }
 
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
+        /// <returns>true if the specified year is leap otherwise false.</returns>
         public static bool IsLeap(long year, bool isGregorianCalendar)
         {
             if (isGregorianCalendar)
@@ -68,6 +103,10 @@ namespace AASharp
             }
         }
 
+        /// <param name="dayOfYear">The day of the year where 1st of January is 1 going up to 365 or 366 for 31st of December</param>
+        /// <param name="isLeap">if the year being considered is a leap year, otherwise false.</param>
+        /// <param name="dayOfMonth">Upon return will contain the day of the month.</param>
+        /// <param name="Month">Upon return will contain the month.</param>
         public static void DayOfYearToDayAndMonth(long dayOfYear, bool isLeap, ref long dayOfMonth, ref long Month)
         {
             long K = isLeap ? 1 : 2;
@@ -84,6 +123,26 @@ namespace AASharp
             dayOfMonth = dayOfYear - INT(275 * Month / 9.0) + K * INT((Month + 9) / 12.0) + 30;
         }
 
+        /// <summary>
+        /// Converts a calendrical date expressed in the Julian Calendar to the equivalent date in the Gregorian Calendar. It is assumed that the adoption of the Gregorian Calendar occurred in 1582.
+        /// </summary>
+        /// <param name="year">The year in the Julian Calendar to convert. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year in the Julian Calendar (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month in the Julian Calendar.</param>
+        /// <returns>
+        /// <para>
+        /// A class containing
+        /// </para>
+        /// <para>
+        /// Year - The year in the Gregorian Calendar. (Years are counted astronomically i.e. 1 BC = Year 0)
+        /// </para>
+        /// <para>
+        /// Month - The month of the year in the Gregorian Calendar(1 for January to 12 for December).
+        /// </para>
+        /// <para>
+        /// Day - The day of the month in the Gregorian Calendar.
+        /// </para>
+        /// </returns>
         public static AASCalendarDate JulianToGregorian(long year, long month, long day)
         {
             AASDate date = new AASDate(year, month, day, false);
@@ -101,6 +160,23 @@ namespace AASharp
             return gregorianDate;
         }
 
+        /// <summary>
+        /// Converts a calendrical date expressed in the Gregorian Calendar to the equivalent date in the Julian Calendar.
+        /// </summary>
+        /// <param name="year">The year in the Gregorian Calendar to convert. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year in the Gregorian Calendar (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month in the Gregorian Calendar.</param>
+        /// <returns>A class containing
+        /// <para>
+        /// Year - The year in the Julian Calendar. (Years are counted astronomically i.e. 1 BC = Year 0)
+        /// </para>
+        /// <para>
+        /// Month - The month of the year in the Julian Calendar(1 for January to 12 for December).
+        /// </para>
+        /// <para>
+        /// Day - The day of the month in the Julian Calendar.
+        /// </para>
+        /// </returns>
         public static AASCalendarDate GregorianToJulian(long year, long month, long day)
         {
             AASDate date = new AASDate(year, month, day, true);
@@ -130,21 +206,35 @@ namespace AASharp
             }
         }
 
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month (Can include decimals).</param>
+        /// <returns>Returns true if the date occurs on or after the Gregorian calendar reform which occurred on 15th October 1582 (which corresponds to Julian Day 2299160.5), otherwise false. Please note that the CAADate class assumes the calendar change occured on this date. Historically of course different countries adopted the reform at different times.</returns>
         public static bool AfterPapalReform(long year, long month, double day)
         {
             return year > 1582 || year == 1582 && month > 10 || year == 1582 && month == 10 && day >= 15;
         }
 
+        /// <param name="JD">The Julian day including decimals</param>
+        /// <returns>Returns true if the date occurs on or after the Gregorian calendar reform which occurred on 15th October 1582 (which corresponds to Julian Day 2299160.5), otherwise false. Please note that the CAADate class assumes the calendar change occured on this date. Historically of course different countries adopted the reform at different times.</returns>
         public static bool AfterPapalReform(double JD)
         {
             return JD >= 2299160.5;
         }
 
+        /// <param name="JD">The Julian day including decimals</param>
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
+        /// <returns>Returns the day of year (including decimals) this date represents.</returns>
         public static double DayOfYear(double JD, long year, bool isGregorianCalendar)
         {
             return JD - DateToJD(year, 1, 1, isGregorianCalendar) + 1;
         }
 
+        /// <param name="month">The month (1 - 12) whose number of days we are looking for.</param>
+        /// <param name="isLeap">true if February is in a leap year, false otherwise.</param>
+        /// <returns>Returns the total number of days in the month (28 - 31) which this date represents. The static version of the function can be used if you do not want to construct a AASDate instance to do this test.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static long DaysInMonth(long month, bool isLeap)
         {
             if (month < 1 || month > 12)
@@ -168,8 +258,14 @@ namespace AASharp
         private double _mDblJulian;
         private bool _mBGregorianCalendar;
 
+        /// <summary>
+        /// Returns the underlying Julian Day including decimals.
+        /// </summary>
         public double Julian => _mDblJulian;
 
+        /// <summary>
+        /// Returns the day of the month this date represents.
+        /// </summary>
         public long Day
         {
             get
@@ -185,6 +281,9 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Returns the month (1 - 12) this date represents.
+        /// </summary>
         public long Month
         {
             get
@@ -200,6 +299,9 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Returns the year this date represents.
+        /// </summary>
         public long Year
         {
             get
@@ -215,6 +317,9 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Returns the hour this date represents.
+        /// </summary>
         public long Hour
         {
             get
@@ -230,6 +335,9 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Returns the minute this date represents.
+        /// </summary>
         public long Minute
         {
             get
@@ -245,6 +353,9 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Returns the seconds this date represents.
+        /// </summary>
         public double Second
         {
             get
@@ -260,8 +371,12 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Returns an enum which identifies which day of the week this date represents.
+        /// </summary>
         public DAY_OF_WEEK DayOfWeek => (DAY_OF_WEEK)((long)(_mDblJulian + 1.5) % 7);
 
+        /// <returns>Returns the day of year (including decimals) this date represents.</returns>
         public double DayOfYear()
         {
             long year = 0;
@@ -275,6 +390,7 @@ namespace AASharp
             return DayOfYear(_mDblJulian, year, AfterPapalReform(year, 1, 1));
         }
 
+        /// <returns>Returns the total number of days in the month (28 - 31) which this date represents. The static version of the function can be used if you do not want to construct a AASDate instance to do this test.</returns>
         public long DaysInMonth()
         {
             long year = 0;
@@ -288,6 +404,7 @@ namespace AASharp
             return DaysInMonth(month, IsLeap(year, _mBGregorianCalendar));
         }
 
+        /// <returns>Returns the total number of days in the year (365 or 366) which this date represents.</returns>
         public long DaysInYear()
         {
             long year = 0;
@@ -301,10 +418,19 @@ namespace AASharp
             return IsLeap(year, _mBGregorianCalendar) ? 366 : 365;
         }
 
+        /// <summary>
+        /// true if the year which this date represents is leap otherwise false.
+        /// </summary>
         public bool Leap => IsLeap(Year, _mBGregorianCalendar);
 
+        /// <summary>
+        /// Returns true if this date is in the Gregorian calendar, false means the Julian Calendar.
+        /// </summary>
         public bool InGregorianCalendar => _mBGregorianCalendar;
 
+        /// <summary>
+        /// Returns the years with decimals this date represents e.g. the middle of the year 2000 would be returned as 2000.5.
+        /// </summary>
         public double FractionalYear
         {
             get
@@ -323,18 +449,37 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Allows the date to be modified after construction.
+        /// </summary>
+        /// <param name="year">The year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="month">The month of the year (1 for January to 12 for December).</param>
+        /// <param name="day">The day of the month (Can include decimals).</param>
+        /// <param name="hour">The hour (Can include decimals).</param>
+        /// <param name="minute">The minute (Can include decimals).</param>
+        /// <param name="second">The seconds (Can include decimals).</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
         public void Set(long year, long month, double day, double hour, double minute, double second, bool isGregorianCalendar)
         {
             double dblDay = day + hour / 24 + minute / 1440 + second / 86400;
             Set(DateToJD(year, month, dblDay, isGregorianCalendar), isGregorianCalendar);
         }
 
+        /// <summary>
+        /// Allows the date to be modified after construction.
+        /// </summary>
+        /// <param name="JD">The Julian day including decimals</param>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
         public void Set(double JD, bool isGregorianCalendar)
         {
             _mDblJulian = JD;
             SetInGregorianCalendar(isGregorianCalendar);
         }
 
+        /// <summary>
+        /// Allows the date's calendar type to be changed after construction.
+        /// </summary>
+        /// <param name="isGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
         public void SetInGregorianCalendar(bool isGregorianCalendar)
         {
             bool bAfterPapalReform = AfterPapalReform(_mDblJulian);
@@ -347,6 +492,15 @@ namespace AASharp
             _mBGregorianCalendar = isGregorianCalendar && bAfterPapalReform;
         }
 
+        /// <summary>
+        /// Allows the date parts to be retrieved.
+        /// </summary>
+        /// <param name="Year">Upon return will contain the year. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="Month">Upon return will contain the month of the year (1 for January to 12 for December).</param>
+        /// <param name="Day">Upon return will contain the day of the month.</param>
+        /// <param name="Hour">Upon return will contain the hour.</param>
+        /// <param name="Minute">Upon return will contain the minute.</param>
+        /// <param name="Second">Upon return will contain the seconds (Can include decimals).</param>
         public void Get(ref long Year, ref long Month, ref long Day, ref long Hour, ref long Minute, ref double Second)
         {
             double JD = _mDblJulian + 0.5;

--- a/Src/AASharp/AASDiameters.cs
+++ b/Src/AASharp/AASDiameters.cs
@@ -2,125 +2,218 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms for the semi diameters of the Sun, Moon, Planets and Asteroids. This refers to Chapter 55 in the book.
+    /// </summary>
     public static class AASDiameters
     {
+        /// <param name="Delta">The distance to the Sun in astronomical units.</param>
+        /// <returns>The suns semi diameter in arc seconds.</returns>
         public static double SunSemidiameterA(double Delta)
         {
             return 959.63 / Delta;
         }
 
+        /// <param name="Delta">The distance to Mercury in astronomical units.</param>
+        /// <returns>Mercury's semi diameter in arc seconds.</returns>
         public static double MercurySemidiameterA(double Delta)
         {
             return 3.34 / Delta;
         }
 
+        /// <param name="Delta">The distance to Venus in astronomical units.</param>
+        /// <returns>Venus's semi diameter in arc seconds.</returns>
         public static double VenusSemidiameterA(double Delta)
         {
             return 8.41 / Delta;
         }
 
+        /// <param name="Delta">The distance to Mars in astronomical units.</param>
+        /// <returns>Mars's semi diameter in arc seconds.</returns>
         public static double MarsSemidiameterA(double Delta)
         {
             return 4.68 / Delta;
         }
 
+        /// <param name="Delta">The distance to Jupiter in astronomical units.</param>
+        /// <returns>Jupiter's equatorial semi diameter in arc seconds.</returns>
         public static double JupiterEquatorialSemidiameterA(double Delta)
         {
             return 98.47 / Delta;
         }
 
+        /// <param name="Delta">The distance to Jupiter in astronomical units.</param>
+        /// <returns>Jupiter's polar semi diameter in arc seconds.</returns>
         public static double JupiterPolarSemidiameterA(double Delta)
         {
             return 91.91 / Delta;
         }
 
+        /// <param name="Delta">The distance to Saturn in astronomical units.</param>
+        /// <returns>Saturn's equatorial semi diameter in arc seconds.</returns>
         public static double SaturnEquatorialSemidiameterA(double Delta)
         {
             return 83.33 / Delta;
         }
 
+        /// <param name="Delta">The distance to Saturn in astronomical units.</param>
+        /// <returns>Saturn's polar semi diameter in arc seconds.</returns>
         public static double SaturnPolarSemidiameterA(double Delta)
         {
             return 74.57 / Delta;
         }
 
+        /// <summary>
+        /// Due to the large inclinations of Saturn, the apparent polar semi diameter can be different to the true polar semi diameter.
+        /// </summary>
+        /// <param name="Delta">The distance to Saturn in astronomical units.</param>
+        /// <param name="B">The Saturnicentric latitude of the Earth in degrees.</param>
+        /// <returns>Saturn's polar semi diameter in arc seconds.</returns>
         public static double ApparentSaturnPolarSemidiameterA(double Delta, double B)
         {
             double cosB = Math.Cos(AASCoordinateTransformation.DegreesToRadians(B));
             return SaturnPolarSemidiameterA(Delta) * Math.Sqrt(1 - 0.199197 * cosB * cosB);
         }
 
+        /// <param name="Delta">The distance to Uranus in astronomical units.</param>
+        /// <returns>Uranus's semi diameter in arc seconds.</returns>
         public static double UranusSemidiameterA(double Delta)
         {
             return 34.28 / Delta;
         }
 
+        /// <param name="Delta">The distance to Neptune in astronomical units.</param>
+        /// <returns>Neptune's semi diameter in arc seconds.</returns>
         public static double NeptuneSemidiameterA(double Delta)
         {
             return 36.56 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Mercury in astronomical units.</param>
+        /// <returns>Mercury's semi diameter in arc seconds.</returns>
         public static double MercurySemidiameterB(double Delta)
         {
             return 3.36 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Venus in astronomical units.</param>
+        /// <returns>Venus's semi diameter in arc seconds.</returns>
         public static double VenusSemidiameterB(double Delta)
         {
             return 8.34 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Mars in astronomical units.</param>
+        /// <returns>Mars's semi diameter in arc seconds.</returns>
         public static double MarsSemidiameterB(double Delta)
         {
             return 4.68 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Jupiter in astronomical units.</param>
+        /// <returns>Jupiter's equatorial semi diameter in arc seconds.</returns>
         public static double JupiterEquatorialSemidiameterB(double Delta)
         {
             return 98.44 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Jupiter in astronomical units.</param>
+        /// <returns>Jupiter's polar semi diameter in arc seconds.</returns>
         public static double JupiterPolarSemidiameterB(double Delta)
         {
             return 92.06 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Saturn in astronomical units.</param>
+        /// <returns>Saturn's equatorial semi diameter in arc seconds.</returns>
         public static double SaturnEquatorialSemidiameterB(double Delta)
         {
             return 82.73 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Saturn in astronomical units.</param>
+        /// <returns>Saturn's polar semi diameter in arc seconds.</returns>
         public static double SaturnPolarSemidiameterB(double Delta)
         {
             return 73.82 / Delta;
         }
 
+        /// <summary>
+        /// Due to the large inclinations of Saturn, the apparent polar semi diameter can be different to the true polar semi diameter. Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Saturn in astronomical units.</param>
+        /// <param name="B">The Saturnicentric latitude of the Earth in degrees.</param>
+        /// <returns>Saturn's polar semi diameter in arc seconds.</returns>
         public static double ApparentSaturnPolarSemidiameterB(double Delta, double B)
         {
             double cosB = Math.Cos(AASCoordinateTransformation.DegreesToRadians(B));
             return SaturnPolarSemidiameterB(Delta) * Math.Sqrt(1 - 0.203800 * cosB * cosB);
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Uranus in astronomical units.</param>
+        /// <returns>Uranus's semi diameter in arc seconds.</returns>
         public static double UranusSemidiameterB(double Delta)
         {
             return 35.02 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Neptune in astronomical units.</param>
+        /// <returns>Neptune's semi diameter in arc seconds.</returns>
         public static double NeptuneSemidiameterB(double Delta)
         {
             return 33.50 / Delta;
         }
 
+        /// <summary>
+        /// Uses the updated Astronomical Almanac for 1984 size.
+        /// </summary>
+        /// <param name="Delta">The distance to Pluto in astronomical units.</param>
+        /// <returns>Pluto's semi diameter in arc seconds.</returns>
         public static double PlutoSemidiameterB(double Delta)
         {
             return 2.07 / Delta;
         }
 
+        /// <param name="Delta">The distance to the Moon in kilometres.</param>
+        /// <returns>The Moon's semi diameter in arc seconds.</returns>
         public static double GeocentricMoonSemidiameter(double Delta)
         {
             return AASCoordinateTransformation.RadiansToDegrees (0.272481 * 6378.14 / Delta) * 3600;
         }
 
+        /// <param name="DistanceDelta">The distance to the Moon in kilometres.</param>
+        /// <param name="Delta">The geocentric declination of the Moon in degrees.</param>
+        /// <param name="H">The geocentric hour angle of the Moon.</param>
+        /// <param name="Latitude">The latitude of the position in degrees.</param>
+        /// <param name="Height">The observer's height above sea level in meters</param>
+        /// <returns>The Moon's semi diameter in arc seconds.</returns>
         public static double TopocentricMoonSemidiameter(double DistanceDelta, double Delta, double H, double Latitude, double Height)
         {
             //Convert to radians
@@ -137,12 +230,18 @@ namespace AASharp
             return AASCoordinateTransformation.RadiansToDegrees(Math.Asin(Math.Sin(s) / q)) * 3600;
         }
 
+        /// <param name="H">The absolute magnitude of the asteroid.</param>
+        /// <param name="A">The albedo of the asteroid.</param>
+        /// <returns>The asteroid's diameter in kilometres.</returns>
         public static double AsteroidDiameter(double H, double A)
         {
             double x = 3.12 - H / 5 - 0.217147 * Math.Log(A);
             return Math.Pow(10.0, x);
         }
 
+        /// <param name="Delta">The distance to the asteroid in astronomical units.</param>
+        /// <param name="d">The diameter of the asteroid in kilometres.</param>
+        /// <returns>The asteroid's apparent diameter in arc seconds.</returns>
         public static double ApparentAsteroidDiameter(double Delta, double d)
         {
             return 0.0013788 * d / Delta;

--- a/Src/AASharp/AASDynamicalTime.cs
+++ b/Src/AASharp/AASDynamicalTime.cs
@@ -2,11 +2,14 @@ using System;
 
 namespace AASharp
 {
-	#region structs
+    #region structs
 
-	#endregion
+    #endregion
 
-	public static class AASDynamicalTime
+    /// <summary>
+    /// This class provides for conversion between Universal Time (both UT1 and UTC) and Terrestrial Time (TT) aka Terrestrial Dynamical Time (TDT) aka Ephemeris Time (ET). This refers to Chapter 10 in the book.
+    /// </summary>
+    public static class AASDynamicalTime
 	{
 		#region constants
 
@@ -18914,9 +18917,12 @@ namespace AASharp
 			new LeapSecondCoefficient(2457754.5, 37.0,      41317, 0.0       ) //1 January 2017
 		};
 
-		#endregion
+        #endregion
 
-		public static double DeltaT(double JD)
+        /// <param name="JD">The Julian day to calculate Cumulative leap seconds for. Because Leap seconds change so slowly, the time used can be in the TT, the UTC or UT1 timeframes although technically leap seconds are only relevant to the UTC timescale.</param>
+        /// <returns>The difference DeltaT which is equal to TT - UT1 in seconds of time.</returns>
+        /// <exception cref="Exception"></exception>
+        public static double DeltaT(double JD)
 		{
 			//What will be the return value from the method
 			double Delta = 0;
@@ -19082,7 +19088,9 @@ namespace AASharp
 			return Delta;
 		}
 
-		public static double CumulativeLeapSeconds(double JD)
+        /// <param name="JD">The Julian day to calculate Cumulative leap seconds for. Because Leap seconds change so slowly, the time used can be in the TT, the UTC or UT1 timeframes although technically leap seconds are only relevant to the UTC timescale.</param>
+        /// <returns>The cumulative total of Leap seconds which have been applied to this point in seconds of time.</returns>
+        public static double CumulativeLeapSeconds(double JD)
 		{
 			//What will be the return value from the method
 			double LeapSeconds = 0;
@@ -19119,7 +19127,9 @@ namespace AASharp
 			return LeapSeconds;
 		}
 
-		public static double TT2UTC(double JD)
+        /// <param name="JD">The Julian day in the TT timeframe to convert.</param>
+        /// <returns>The Julian day in the UTC timeframe.</returns>
+        public static double TT2UTC(double JD)
 		{
 			//Outside of the range 1 January 1961 to 500 days after the last leap second,
 			//we implement TT2UTC as TT2UT1
@@ -19133,7 +19143,9 @@ namespace AASharp
 			return ((DT - LeapSeconds - 32.184) / 86400.0) + UT1;
 		}
 
-		public static double UTC2TT(double JD)
+        /// <param name="JD">The Julian day in the UTC timeframe to convert.</param>
+        /// <returns>The Julian day in the TT timeframe.</returns>
+        public static double UTC2TT(double JD)
 		{
 			//Outside of the range 1 January 1961 to 500 days after the last leap second,
 			//we implement TT2UTC as TT2UT1
@@ -19147,27 +19159,37 @@ namespace AASharp
 			return UT1 + (DT / 86400.0);
 		}
 
-		public static double TT2TAI(double JD)
+        /// <param name="JD">The Julian day in the TT timeframe to convert.</param>
+        /// <returns>The Julian day in the TAI timeframe.</returns>
+        public static double TT2TAI(double JD)
 		{
 			return JD - (32.184 / 86400.0);
 		}
 
-		public static double TAI2TT(double JD)
+        /// <param name="JD">The Julian day in the TAI timeframe to convert.</param>
+        /// <returns>The Julian day in the TT timeframe.</returns>
+        public static double TAI2TT(double JD)
 		{
 			return JD + (32.184 / 86400.0);
 		}
 
-		public static double TT2UT1(double JD)
+        /// <param name="JD">The Julian day in the TT timeframe to convert.</param>
+        /// <returns>The Julian day in the UT1 timeframe.</returns>
+        public static double TT2UT1(double JD)
 		{
 			return JD - (DeltaT(JD) / 86400.0);
 		}
 
-		public static double UT12TT(double JD)
+        /// <param name="JD">The Julian day in the UT1 timeframe to convert.</param>
+        /// <returns>The Julian day in the TT timeframe.</returns>
+        public static double UT12TT(double JD)
 		{
 			return JD + (DeltaT(JD) / 86400.0);
 		}
 
-		public static double UT1MinusUTC(double JD)
+        /// <param name="JD">The Julian day in the UT1 timeframe.</param>
+        /// <returns>The difference between UT1 and UTC in seconds of time.</returns>
+        public static double UT1MinusUTC(double JD)
 		{
 			double JDUTC = JD + ((DeltaT(JD) - CumulativeLeapSeconds(JD) - 32.184) / 86400);
 			return (JD - JDUTC) * 86400;

--- a/Src/AASharp/AASEarth.cs
+++ b/Src/AASharp/AASEarth.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of the Earth. This refers to Chapter 32 and parts of Chapter 26 and 47 in the book
+    /// </summary>
     public static class AASEarth
     {
         #region coefficient
@@ -368,9 +371,12 @@ namespace AASharp
             new VSOP87Coefficient( 6,  2.27, 6283.08 ),
             new VSOP87Coefficient( 1,  0,    0 )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -428,6 +434,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -459,6 +468,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -505,6 +517,9 @@ namespace AASharp
             return (R0 + R1 * rho + R2 * rhosquared + R3 * rhocubed + R4 * rho4) / 100000000;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of J2000 in the VSOP theory.</returns>
         public static double EclipticLongitudeJ2000(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -555,6 +570,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of J2000 defined in the VSOP theory.</returns>
         public static double EclipticLatitudeJ2000(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -605,6 +623,8 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean anomaly of the Sun in degrees.</returns>
         public static double SunMeanAnomaly(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -613,6 +633,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(357.5291092 + 35999.0502909 * T - 0.0001536 * Tsquared + Tcubed / 24490000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of Earth's orbit.</returns>
         public static double Eccentricity(double JD)
         {
             double T = (JD - 2451545) / 36525;

--- a/Src/AASharp/AASEaster.cs
+++ b/Src/AASharp/AASEaster.cs
@@ -1,7 +1,19 @@
 namespace AASharp
 {
-    public static class AASEaster
-    {
+    /// <summary>
+    /// This class provides for calculation of the date of Easter in both the Julian and Gregorian calendars. This refers to Chapter 8 in the book.
+    /// </summary>
+    public static class AASEaster {
+        /// <param name="nYear">The year to perform the calculation for.</param>
+        /// <param name="GregorianCalendar">true if the calculation is to be performed for the Gregorian calendar, false implies the Julian Calendar</param>
+        /// <returns>A class containing
+        /// <para>
+        /// Month - The month on which Easter Sunday occurs.
+        /// </para>
+        /// <para>
+        /// Day - The day of the month on which Easter Sunday occurs.
+        /// </para>
+        /// </returns>
         public static AASEasterDetails Calculate(long nYear, bool GregorianCalendar)
         {
             AASEasterDetails details = null;

--- a/Src/AASharp/AASEasterDetails.cs
+++ b/Src/AASharp/AASEasterDetails.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASEaster.Calculate method.
+    /// </summary>
     public class AASEasterDetails
     {
         public AASEasterDetails(long month, long day)
@@ -7,8 +10,13 @@
             Month = month;
             Day = day;
         }
-
+        /// <summary>
+        /// The month on which Easter Sunday occurs.
+        /// </summary>
         public long Month { get; }
+        /// <summary>
+        /// The day of the month on which Easter Sunday occurs.
+        /// </summary>
         public long Day { get; }
     }
 }

--- a/Src/AASharp/AASEclipses.cs
+++ b/Src/AASharp/AASEclipses.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of Solar and Lunar Eclipses. This refers to Chapter 54 in the book.
+    /// </summary>
     public static class AASEclipses
     {
         private static AASSolarEclipseDetails Calculate(double k, ref double Mdash)
@@ -146,6 +149,28 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="k">The same K term as returned from AASMoonPhases.K. For a solar eclipse, this value should be a value without any decimals as a solar eclipse refers to a New Moon.</param>
+        /// <returns>A struct containing the following values:
+        /// <para>
+        /// Flags - A bitmask which indicates the type of solar eclipse which has occurred.See the constant values defined in AASSolarEclopseDetails for more information.
+        /// </para>
+        /// <para>
+        /// TimeOfMaximumEclipse - The date in Dynamical time of maximum eclipse.
+        /// </para>
+        /// <para>
+        /// F - The moons argument of Latitude in degrees at the time of the eclipse.
+        /// </para>
+        /// <para>
+        /// u - The U term for the eclipse.
+        /// </para>
+        /// <para>
+        /// gamma - The gamma term for the eclipse.
+        /// </para>
+        /// <para>
+        /// GreatestMagnitude - The greatest magnitude of the eclipse if the eclipse is partial.
+        /// </para>
+        /// </returns>
+        /// <exception cref="NotSupportedException"></exception>
         public static AASSolarEclipseDetails CalculateSolar(double k)
         {
 #if DEBUG
@@ -158,7 +183,46 @@ namespace AASharp
             return Calculate(k, ref Mdash);
         }
 
-
+        /// <param name="k">The same K term as returned from AASMoonPhases.K. For a lunar eclipse, this value should be decimal value incremented by 0.5 as a lunar eclipse refers to a Full Moon.</param>
+        /// <returns>A struct containing the following values:
+        /// <para>
+        /// bEclipse - true if a lunar eclipse occurs at this Full Moon.
+        /// </para>
+        /// <para>
+        /// TimeOfMaximumEclipse - The date in Dynamical time of maximum eclipse.
+        /// </para>
+        /// <para>
+        /// F - The moons argument of Latitude in degrees at the time of the eclipse.
+        /// </para>
+        /// <para>
+        /// u - The U term for the eclipse.
+        /// </para>
+        /// <para>
+        /// gamma - The gamma term for the eclipse.
+        /// </para>
+        /// <para>
+        /// PenumbralRadii - The radii of the eclipse for the penumbra in equatorial earth radii.
+        /// </para>
+        /// <para>
+        /// UmbralRadii - The radii of the eclipse for the umbra in equatorial earth radii.
+        /// </para>
+        /// <para>
+        /// PenumbralMagnitude - The magnitude of the eclipse if the eclipse is penumbral.
+        /// </para>
+        /// <para>
+        /// UmbralMagnitude - The magnitude of the eclipse if the eclipse is umbral.
+        /// </para>
+        /// <para>
+        /// PartialPhaseSemiDuration - The semi-duration of the eclipse during the partial phase.
+        /// </para>
+        /// <para>
+        /// TotalPhaseSemiDuration - The semi-duration of the eclipse during the total phase.
+        /// </para>
+        /// <para>
+        /// PartialPhasePenumbralSemiDuration - The semi-duration of the partial phase in the penumbra.
+        /// </para>
+        /// </returns>
+        /// <exception cref="NotSupportedException"></exception>
         public static AASLunarEclipseDetails CalculateLunar(double k)
         {
 #if DEBUG

--- a/Src/AASharp/AASEclipticalElementDetails.cs
+++ b/Src/AASharp/AASEclipticalElementDetails.cs
@@ -1,9 +1,21 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASEclipticalElements.Calculate and AASEclipticalElements.FK4B1950ToFK5J2000
+    /// </summary>
     public class AASEclipticalElementDetails
     {
+        /// <summary>
+        /// The reduced inclination in degrees.
+        /// </summary>
         public double i { get; set; }
+        /// <summary>
+        /// The reduced argument of perihelion in degrees.
+        /// </summary>
         public double w { get; set; }
+        /// <summary>
+        /// The reduced longitude of the ascending node in degrees
+        /// </summary>
         public double omega { get; set; }
     }
 }

--- a/Src/AASharp/AASEclipticalElements.cs
+++ b/Src/AASharp/AASEclipticalElements.cs
@@ -2,8 +2,26 @@ using System;
 
 namespace AASharp
 {
-    public static class AASEclipticalElements
-    {
+    /// <summary>
+    /// This class provides the algorithms which map ecliptical elements from one equinox to another. This refers to Chapter 24 in the book.
+    /// </summary>
+    public static class AASEclipticalElements {
+        /// <param name="i0">The inclination in degrees to reduce.</param>
+        /// <param name="w0">The argument of perihelion in degrees to reduce.</param>
+        /// <param name="omega0">The longitude of the ascending node in degrees to reduce.</param>
+        /// <param name="JD0">The initial epoch in Dynamical time to calculate for.</param>
+        /// <param name="JD">The epoch in Dynamical time to reduce the elements to.</param>
+        /// <returns>A struct containing the following values:
+        /// <para>
+        /// i - The reduced inclination in degrees.
+        /// </para>
+        /// <para>
+        /// w - The reduced argument of perihelion in degrees.
+        /// </para>
+        /// <para>
+        /// omega - The reduced longitude of the ascending node in degrees
+        /// </para>
+        /// </returns>
         public static AASEclipticalElementDetails Calculate(double i0, double w0, double omega0, double JD0, double JD)
         {
             double T = (JD0 - 2451545.0) / 36525;
@@ -53,6 +71,20 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="i0">The inclination in degrees to reduce.</param>
+        /// <param name="w0">The argument of perihelion in degrees to reduce.</param>
+        /// <param name="omega0">The longitude of the ascending node in degrees to reduce.</param>
+        /// <returns>A struct containing the following values:
+        /// <para>
+        /// i - The reduced inclination in degrees.
+        /// </para>
+        /// <para>
+        /// w - The reduced argument of perihelion in degrees.
+        /// </para>
+        /// <para>
+        /// omega - The reduced longitude of the ascending node in degrees
+        /// </para>
+        /// </returns>
         public static AASEclipticalElementDetails FK4B1950ToFK5J2000(double i0, double w0, double omega0)
         {
             //convert to radians

--- a/Src/AASharp/AASElementsPlanetaryOrbit.cs
+++ b/Src/AASharp/AASElementsPlanetaryOrbit.cs
@@ -1,7 +1,12 @@
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms to calculate the elements of the planetary orbits. This refers to Chapter 31 in the book.
+    /// </summary>
     public static class AASElementsPlanetaryOrbit
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MercuryMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -11,12 +16,15 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(252.250906 + 149474.0722491 * T + 0.00030350 * Tsquared +
                                                               0.000000018 * Tcubed);
         }
-    
+
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double MercurySemimajorAxis( /*JD*/)
         {
             return 0.387098310;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double MercuryEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -25,7 +33,9 @@ namespace AASharp
     
             return 0.20563175 + 0.000020407 * T - 0.0000000283 * Tsquared - 0.00000000018 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MercuryInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -35,7 +45,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(7.004986 + 0.0018215 * T - 0.00001810 * Tsquared +
                                                               0.000000056 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MercuryLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -45,7 +57,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(48.330893 + 1.1861883 * T + 0.00017542 * Tsquared +
                                                               0.000000215 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MercuryLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -55,7 +69,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(77.456119 + 1.5564776 * T + 0.00029544 * Tsquared +
                                                               0.000000009 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double VenusMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -65,12 +81,15 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(181.979801 + 58519.2130302 * T + 0.00031014 * Tsquared +
                                                               0.000000015 * Tcubed);
         }
-    
+
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double VenusSemimajorAxis( /*double JD*/)
         {
             return 0.723329820;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double VenusEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -79,7 +98,9 @@ namespace AASharp
     
             return 0.00677192 - 0.000047765 * T + 0.0000000981 * Tsquared + 0.00000000046 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double VenusInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -89,7 +110,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(3.394662 + 0.0010037 * T - 0.00000088 * Tsquared -
                                                               0.000000007 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double VenusLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -99,7 +122,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(76.679920 + 0.9011206 * T + 0.00040618 * Tsquared -
                                                               0.000000093 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double VenusLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -109,7 +134,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(131.563703 + 1.4022288 * T - 0.00107618 * Tsquared -
                                                               0.000005678 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double EarthMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -119,12 +146,15 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(100.466457 + 36000.7698278 * T + 0.00030322 * Tsquared +
                                                               0.000000020 * Tcubed);
         }
-    
+
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double EarthSemimajorAxis( /*double JD*/)
         {
             return 1.000001018;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double EarthEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -133,12 +163,15 @@ namespace AASharp
     
             return 0.01670863 - 0.000042037 * T - 0.0000001267 * Tsquared + 0.00000000014 * Tcubed;
         }
-    
+
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double EarthInclination( /*double JD*/)
         {
             return 0;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double EarthLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -148,7 +181,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(102.937348 + 1.17195366 * T + 0.00045688 * Tsquared -
                                                               0.000000018 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MarsMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -158,12 +193,15 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(355.433000 + 19141.6964471 * T + 0.00031052 * Tsquared +
                                                               0.000000016 * Tcubed);
         }
-    
+
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double MarsSemimajorAxis( /*double JD*/)
         {
             return 1.523679342;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double MarsEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -172,7 +210,9 @@ namespace AASharp
     
             return 0.09340065 + 0.000090484 * T - 0.0000000806 * Tsquared - 0.00000000025 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MarsInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -182,7 +222,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(1.849726 - 0.0006011 * T + 0.00001276 * Tsquared -
                                                               0.000000007 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MarsLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -192,7 +234,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(49.588093 + 0.7720959 * T + 0.00001557 * Tsquared +
                                                               0.000002267 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double MarsLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -202,7 +246,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(336.060234 + 1.8410449 * T + 0.00013477 * Tsquared +
                                                               0.000000536 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double JupiterMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -212,14 +258,18 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(34.351519 + 3036.3027748 * T + 0.00022330 * Tsquared +
                                                               0.000000037 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double JupiterSemimajorAxis(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
     
             return 5.202603209 + 0.0000001913 * T;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double JupiterEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -228,7 +278,9 @@ namespace AASharp
     
             return 0.04849793 + 0.000163225 * T - 0.0000004714 * Tsquared - 0.00000000201 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double JupiterInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -238,7 +290,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(1.303267 - 0.0054965 * T + 0.00000466 * Tsquared -
                                                               0.000000002 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double JupiterLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -248,7 +302,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(100.464407 + 1.0209774 * T + 0.00040315 * Tsquared +
                                                               0.000000404 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double JupiterLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -258,7 +314,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(14.331207 + 1.6126352 * T + 0.00103042 * Tsquared -
                                                               0.000004464 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double SaturnMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -268,7 +326,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(50.077444 + 1223.5110686 * T + 0.00051908 * Tsquared -
                                                               0.000000030 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double SaturnSemimajorAxis(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -276,7 +336,9 @@ namespace AASharp
     
             return 9.554909192 - 0.0000021390 * T + 0.000000004 * Tsquared;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double SaturnEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -285,7 +347,9 @@ namespace AASharp
     
             return 0.05554814 - 0.0003446641 * T - 0.0000006436 * Tsquared + 0.00000000340 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double SaturnInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -295,7 +359,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(2.488879 - 0.0037362 * T - 0.00001519 * Tsquared +
                                                               0.000000087 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double SaturnLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -305,7 +371,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(113.665503 + 0.8770880 * T - 0.00012176 * Tsquared -
                                                               0.000002249 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double SaturnLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -315,7 +383,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(93.057237 + 1.9637613 * T + 0.00083753 * Tsquared +
                                                               0.000004928 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double UranusMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -325,7 +395,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(314.055005 + 429.8640561 * T + 0.00030390 * Tsquared +
                                                               0.000000026 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double UranusSemimajorAxis(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -333,7 +405,9 @@ namespace AASharp
     
             return 19.218446062 - 0.0000000372 * T + 0.00000000098 * Tsquared;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double UranusEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -342,7 +416,9 @@ namespace AASharp
     
             return 0.04638122 - 0.000027293 * T + 0.0000000789 * Tsquared + 0.00000000024 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double UranusInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -352,7 +428,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(0.773197 + 0.0007744 * T + 0.00003749 * Tsquared -
                                                               0.000000092 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double UranusLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -362,7 +440,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(74.005957 + 0.5211278 * T + 0.00133947 * Tsquared +
                                                               0.000018484 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double UranusLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -372,7 +452,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(173.005291 + 1.4863790 * T + 0.00021406 * Tsquared +
                                                               0.000000434 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double NeptuneMeanLongitude(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -382,7 +464,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(304.348665 + 219.8833092 * T + 0.00030882 * Tsquared +
                                                               0.000000018 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi major axis of the planet in astronomical units.</returns>
         public static double NeptuneSemimajorAxis(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -390,7 +474,9 @@ namespace AASharp
     
             return 30.110386869 - 0.0000001663 * T + 0.00000000069 * Tsquared;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the eccentricity of the orbit.</returns>
         public static double NeptuneEccentricity(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -398,7 +484,9 @@ namespace AASharp
     
             return 0.00945575 + 0.000006033 * T - 0.00000000005 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double NeptuneInclination(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -408,7 +496,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(1.769953 - 0.0093082 * T - 0.00000708 * Tsquared +
                                                               0.000000027 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double NeptuneLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -418,7 +508,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(131.784057 + 1.1022039 * T + 0.00025952 * Tsquared -
                                                               0.000000637 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the ecliptic and mean equinox of the date.</returns>
         public static double NeptuneLongitudePerihelion(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -428,7 +520,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(48.120276 + 1.4262957 * T + 0.00038434 * Tsquared +
                                                               0.000000020 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MercuryMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -438,7 +532,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(252.250906 + 149472.6746358 * T - 0.00000536 * Tsquared +
                                                               0.000000002 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MercuryInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -448,7 +544,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(7.004986 - 0.0059516 * T + 0.00000080 * Tsquared +
                                                               0.000000043 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MercuryLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -458,7 +556,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(48.330893 - 0.1254227 * T - 0.00008833 * Tsquared -
                                                               0.000000200 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MercuryLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -468,7 +568,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(77.456119 + 0.1588643 * T - 0.00001342 * Tsquared -
                                                               0.000000007 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double VenusMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -478,7 +580,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(181.979801 + 58517.8156760 * T + 0.00000165 * Tsquared -
                                                               0.000000002 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double VenusInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -488,7 +592,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(3.394662 - 0.0008568 * T - 0.00003244 * Tsquared +
                                                               0.000000009 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double VenusLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -498,7 +604,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(76.679920 - 0.2780134 * T - 0.00014257 * Tsquared -
                                                               0.000000164 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double VenusLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -508,7 +616,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(131.563703 + 0.0048746 * T - 0.00138467 * Tsquared -
                                                               0.000005695 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double EarthMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -518,7 +628,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(100.466457 + 35999.3728565 * T - 0.00000568 * Tsquared -
                                                               0.000000001 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double EarthInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -527,7 +639,9 @@ namespace AASharp
     
             return 0.0130548 * T - 0.00000931 * Tsquared - 0.000000034 * Tcubed;
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double EarthLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -537,7 +651,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(174.873176 - 0.241098 * T + 0.00004262 * Tsquared +
                                                               0.000000001 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double EarthLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -547,7 +663,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(102.937348 + 0.3225654 * T + 0.00014799 * Tsquared -
                                                               0.000000039 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MarsMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -557,7 +675,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(355.433000 + 19140.2993039 * T + 0.00000262 * Tsquared -
                                                               0.000000003 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MarsInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -567,7 +687,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(1.849726 - 0.0081477 * T - 0.00002255 * Tsquared -
                                                               0.000000029 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MarsLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -577,7 +699,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(49.588093 - 0.2950250 * T - 0.00064048 * Tsquared -
                                                               0.000001964 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double MarsLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -587,7 +711,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(336.060234 + 0.4439016 * T - 0.00017313 * Tsquared +
                                                               0.000000518 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double JupiterMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -597,7 +723,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(34.351519 + 3034.9056606 * T - 0.00008501 * Tsquared +
                                                               0.000000016 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double JupiterInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -607,7 +735,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(1.303267 - 0.0019877 * T + 0.00003320 * Tsquared +
                                                               0.000000097 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double JupiterLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -617,7 +747,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(100.464407 + 0.1767232 * T + 0.00090700 * Tsquared -
                                                               0.000007272 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double JupiterLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -627,7 +759,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(14.331207 + 0.2155209 * T + 0.00072211 * Tsquared -
                                                               0.000004485 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double SaturnMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -637,7 +771,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(50.077444 + 1222.1138488 * T + 0.00021004 * Tsquared -
                                                               0.000000046 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double SaturnInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -647,7 +783,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(2.488879 + 0.0025514 * T - 0.00004906 * Tsquared +
                                                               0.000000017 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double SaturnLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -657,7 +795,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(113.665503 - 0.2566722 * T - 0.00018399 * Tsquared +
                                                               0.000000480 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double SaturnLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -667,7 +807,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(93.057237 + 0.5665415 * T + 0.00052850 * Tsquared +
                                                               0.000004912 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double UranusMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -677,7 +819,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(314.055005 + 428.4669983 * T - 0.00000486 * Tsquared +
                                                               0.000000006 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double UranusInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -687,7 +831,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(0.773197 - 0.0016869 * T + 0.00000349 * Tsquared +
                                                               0.000000016 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double UranusLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -697,7 +843,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(74.005957 + 0.0741431 * T + 0.00040539 * Tsquared +
                                                               0.000000119 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double UranusLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -707,7 +855,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(173.005291 + 0.0893212 * T - 0.00009470 * Tsquared +
                                                               0.000000414 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the planet in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double NeptuneMeanLongitudeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -717,7 +867,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(304.348665 + 218.4862002 * T + 0.00000059 * Tsquared -
                                                               0.000000002 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the inclination on the plane of the ecliptic in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double NeptuneInclinationJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -725,7 +877,9 @@ namespace AASharp
     
             return AASCoordinateTransformation.MapTo0To360Range(1.769953 + 0.0002256 * T + 0.00000023 * Tsquared);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the ascending node in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double NeptuneLongitudeAscendingNodeJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;
@@ -735,7 +889,9 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(131.784057 - 0.0061651 * T - 0.00000219 * Tsquared -
                                                               0.000000078 * Tcubed);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the longitude of the perihelion in degrees with respect to the fixed ecliptic of J2000.</returns>
         public static double NeptuneLongitudePerihelionJ2000(double JD)
         {
             double T = (JD - 2451545.0) / 36525;

--- a/Src/AASharp/AASElliptical.cs
+++ b/Src/AASharp/AASElliptical.cs
@@ -2,13 +2,22 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the position of an object in an elliptical orbit. This refers to Chapter 33 in the book.
+    /// </summary>
     public static class AASElliptical
     {
+        /// <param name="Distance">The distance in astronomical units to convert.</param>
+        /// <returns>The light travel time in days corresponding to the distance.</returns>
         public static double DistanceToLightTime(double Distance)
         {
             return Distance * 0.0057755183;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="ellipticalObject">An enum specifying which object (Planet except Earth or the Sun) the calculation is to be carried out for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of the class AASEllipticalPlanetaryDetails with details.</returns>
         public static AASEllipticalPlanetaryDetails Calculate(double JD, AASEllipticalObject ellipticalObject, bool bHighPrecision)
         {
             //What will the the return value
@@ -189,16 +198,25 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="q">The perihelion distance in astronomical units.</param>
+        /// <param name="e">The eccentricity of the orbit.</param>
+        /// <returns>The semi major axis of the orbit in astronomical units.</returns>
         public static double SemiMajorAxisFromPerihelionDistance(double q, double e)
         {
             return q / (1 - e);
         }
 
+        /// <param name="a">The semi major axis of the orbit in astronomical units.</param>
+        /// <returns>The mean motion in degrees / day.</returns>
         public static double MeanMotionFromSemiMajorAxis(double a)
         {
             return 0.9856076686 / (a * Math.Sqrt(a));
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="elements">The orbital elements of elliptical object.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of the class AASEllipticalObjectDetails with details.</returns>
         public static AASEllipticalObjectDetails Calculate(double JD, ref AASEllipticalObjectElements elements, bool bHighPrecision)
         {
             double Epsilon = AASNutation.MeanObliquityOfEcliptic(elements.JDEquinox);
@@ -308,32 +326,61 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="r">The distance of the object from the Sun in astronomical units.</param>
+        /// <param name="a">The semi major axis of the orbit in astronomical units.</param>
+        /// <returns>The instantaneous velocity of the object in kilometres per second.</returns>
         public static double InstantaneousVelocity(double r, double a)
         {
             return 42.1219 * Math.Sqrt((1 / r) - (1 / (2 * a)));
         }
 
+        /// <param name="e">The eccentricity of the orbit.</param>
+        /// <param name="a">The semi major axis of the orbit in astronomical units.</param>
+        /// <returns>The velocity of the object in kilometres per second at perihelion.</returns>
         public static double VelocityAtPerihelion(double e, double a)
         {
             return 29.7847 / Math.Sqrt(a) * Math.Sqrt((1 + e) / (1 - e));
         }
 
+        /// <param name="e">The eccentricity of the orbit.</param>
+        /// <param name="a">The semi major axis of the orbit in astronomical units.</param>
+        /// <returns>The velocity of the object in kilometres per second at aphelion.</returns>
         public static double VelocityAtAphelion(double e, double a)
         {
             return 29.7847 / Math.Sqrt(a) * Math.Sqrt((1 - e) / (1 + e));
         }
 
+        /// <param name="e">The eccentricity of the orbit.</param>
+        /// <param name="a">The semi major axis of the orbit in astronomical units.</param>
+        /// <returns>The length of the eclipse in astronomical units.</returns>
         public static double LengthOfEllipse(double e, double a)
         {
             double b = a * Math.Sqrt(1 - e * e);
             return AASCoordinateTransformation.PI() * (3 * (a + b) - Math.Sqrt((a + 3 * b) * (3 * a + b)));
         }
 
+        /// <summary>
+        /// This refers to algorithm 33.13 on page 231
+        /// </summary>
+        /// <param name="g">The absolute magnitude of the comet.</param>
+        /// <param name="delta">Distance of the comet to the Earth in astronomical units.</param>
+        /// <param name="k">A constant which differs from one comet to another.</param>
+        /// <param name="r">Distance of the comet from the Sun in astronomical units</param>
+        /// <returns>The magnitude of the comet.</returns>
         public static double CometMagnitude(double g, double delta, double k, double r)
         {
             return g + 5 * Math.Log10(delta) + k * Math.Log10(r);
         }
 
+        /// <summary>
+        /// This refers to algorithm 33.14 on page 231
+        /// </summary>
+        /// <param name="H">The mean absolute visual magnitude of the minor planet.</param>
+        /// <param name="delta">Distance of the minor planet to the Earth in astronomical units.</param>
+        /// <param name="G">The so called "slope parameter" which differs from one minor planet to another.</param>
+        /// <param name="r">Distance of the minor planet from the Sun in astronomical units</param>
+        /// <param name="PhaseAngle">the Sun - body - Earth angle in degrees</param>
+        /// <returns>The magnitude of the minor planet.</returns>
         public static double MinorPlanetMagnitude(double H, double delta, double G, double r, double PhaseAngle)
         {
             //Convert from degrees to radians

--- a/Src/AASharp/AASEllipticalObject.cs
+++ b/Src/AASharp/AASEllipticalObject.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An enumeration used by the AASElliptical.Calculate method.
+    /// </summary>
     public enum AASEllipticalObject
     {
         SUN,

--- a/Src/AASharp/AASEllipticalObjectDetails.cs
+++ b/Src/AASharp/AASEllipticalObjectDetails.cs
@@ -1,20 +1,65 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASElliptical.Calculate method.
+    /// </summary>
     public class AASEllipticalObjectDetails
     {
+        /// <summary>
+        /// 3D rectangular heliocentric equatorial coordinates of the object.
+        /// </summary>
         public AAS3DCoordinate HeliocentricRectangularEquatorial { get; set; }
+        /// <summary>
+        /// 3D rectangular heliocentric ecliptical coordinates of the object.
+        /// </summary>
         public AAS3DCoordinate HeliocentricRectangularEcliptical { get; set; }
+        /// <summary>
+        /// The heliocentric ecliptical longitude in degrees of the object.
+        /// </summary>
         public double HeliocentricEclipticLongitude { get; set; }
+        /// <summary>
+        /// The heliocentric ecliptical latitude in degrees of the object.
+        /// </summary>
         public double HeliocentricEclipticLatitude { get; set; }
+        /// <summary>
+        /// The geocentric right ascension of the object as an hour angle (i.e. without light time correction applied).
+        /// </summary>
         public double TrueGeocentricRA { get; set; }
+        /// <summary>
+        /// The geocentric declination of the object in degrees (i.e. without light time correction applied).
+        /// </summary>
         public double TrueGeocentricDeclination { get; set; }
+        /// <summary>
+        /// The true distance in astronomical units between the Earth and the object.
+        /// </summary>
         public double TrueGeocentricDistance { get; set; }
+        /// <summary>
+        /// The light travel time in days from the Earth to the object.
+        /// </summary>
         public double TrueGeocentricLightTime { get; set; }
+        /// <summary>
+        /// The geocentric right ascension of the object as an hour angle (i.e. with light time correction applied)
+        /// </summary>
         public double AstrometricGeocentricRA { get; set; }
+        /// <summary>
+        /// The geocentric declination of the object in degrees (i.e. with light time correction applied)
+        /// </summary>
         public double AstrometricGeocentricDeclination { get; set; }
+        /// <summary>
+        /// The observed distance of the object in astronomical units.
+        /// </summary>
         public double AstrometricGeocentricDistance { get; set; }
+        /// <summary>
+        /// The observed light travel time of the object in days.
+        /// </summary>
         public double AstrometricGeocentricLightTime { get; set; }
+        /// <summary>
+        /// The elongation of the object to the Sun in degrees.
+        /// </summary>
         public double Elongation { get; set; }
+        /// <summary>
+        /// The phase angle (the angle Sun - object - Earth) in degrees.
+        /// </summary>
         public double PhaseAngle { get; set; }
     }
 }

--- a/Src/AASharp/AASEllipticalObjectElements.cs
+++ b/Src/AASharp/AASEllipticalObjectElements.cs
@@ -1,13 +1,37 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// A class to define the orbital elements used by the AASElliptical.Calculate method.
+    /// </summary>
     public class AASEllipticalObjectElements
     {
+        /// <summary>
+        /// The semi major axis in astronomical units.
+        /// </summary>
         public double a { get; set; }
+        /// <summary>
+        /// The eccentricity of the orbit.
+        /// </summary>
         public double e { get; set; }
+        /// <summary>
+        /// The inclination of the plane of the orbit in degrees.
+        /// </summary>
         public double i { get; set; }
+        /// <summary>
+        /// The argument of the perihelion in degrees.
+        /// </summary>
         public double w { get; set; }
+        /// <summary>
+        /// The longitude of the ascending node in degrees.
+        /// </summary>
         public double omega { get; set; }
+        /// <summary>
+        /// The Julian day for which equatorial coordinates should be calculated for.
+        /// </summary>
         public double JDEquinox { get; set; }
+        /// <summary>
+        /// The Julian date of the time of passage in perihelion.
+        /// </summary>
         public double T { get; set; }
     }
 }

--- a/Src/AASharp/AASEllipticalPlanetaryDetails.cs
+++ b/Src/AASharp/AASEllipticalPlanetaryDetails.cs
@@ -1,12 +1,33 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASElliptical.Calculate method.
+    /// </summary>
     public class AASEllipticalPlanetaryDetails
     {
+        /// <summary>
+        /// The apparent geocentric ecliptical longitude in degrees of the object.
+        /// </summary>
         public double ApparentGeocentricLongitude { get; set; }
+        /// <summary>
+        /// The apparent geocentric ecliptical latitude in degrees of the object.
+        /// </summary>
         public double ApparentGeocentricLatitude { get; set; }
+        /// <summary>
+        /// The apparent distance in astronomical units between the object and the Earth.
+        /// </summary>
         public double ApparentGeocentricDistance { get; set; }
+        /// <summary>
+        /// The apparent light travel time in days.
+        /// </summary>
         public double ApparentLightTime { get; set; }
+        /// <summary>
+        /// The apparent right ascension of the planet as an hour angle.
+        /// </summary>
         public double ApparentGeocentricRA { get; set; }
+        /// <summary>
+        /// The apparent declination of the planet in degrees.
+        /// </summary>
         public double ApparentGeocentricDeclination { get; set; }
     }
 }

--- a/Src/AASharp/AASEquationOfTime.cs
+++ b/Src/AASharp/AASEquationOfTime.cs
@@ -2,8 +2,14 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the Equation of Time. This refers to Chapter 28 in the book.
+    /// </summary>
     public static class AASEquationOfTime
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the equation of time in decimal minutes.</returns>
         public static double Calculate(double JD, bool bHighPrecision)
         {
             double rho = (JD - 2451545) / 365250;

--- a/Src/AASharp/AASEquinoxSolsticeDetails2.cs
+++ b/Src/AASharp/AASEquinoxSolsticeDetails2.cs
@@ -1,6 +1,9 @@
 namespace AASharp
 {
-    public class  AASEquinoxSolsticeDetails2
+    /// <summary>
+    /// List of instances of this class is returned by the AASEquinoxesAndSolstices2.Calculate method.
+    /// </summary>
+    public class AASEquinoxSolsticeDetails2
     {
         public enum Type
         {

--- a/Src/AASharp/AASEquinoxesAndSolstices.cs
+++ b/Src/AASharp/AASEquinoxesAndSolstices.cs
@@ -2,8 +2,17 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms to calculate the dates of the Equinoxes and Solstices. This refers to Chapter 27 in the book.
+    /// </summary>
     public static class AASEquinoxesAndSolstices
     {
+        /// <summary>
+        /// Calculates the date of Spring Equinox.
+        /// </summary>
+        /// <param name="Year">The year to calculate the occurrence for. Note that this method refers to "Northward Equinox" instead of "Spring Equinox" to avoid a northern hemisphere-specific bias.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The date in Dynamical time when the sun crosses the equator in a northerly direction.</returns>
         public static double NorthwardEquinox(long Year, bool bHighPrecision)
         {
             //calculate the approximate date
@@ -37,6 +46,12 @@ namespace AASharp
             return JDE;
         }
 
+        /// <summary>
+        /// Calculates the date of Summer Solstice.
+        /// </summary>
+        /// <param name="Year">The year to calculate the occurrence for. Note that this method refers to "Northern Solstice" instead of "Summer Solstice" to avoid a northern hemisphere-specific bias.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The date in Dynamical time when the sun reaches its highest relative to the celestial equator and appears directly over the Tropic of Cancer.</returns>
         public static double NorthernSolstice(long Year, bool bHighPrecision)
         {
             //calculate the approximate date
@@ -70,6 +85,12 @@ namespace AASharp
             return JDE;
         }
 
+        /// <summary>
+        /// Calculates the date of Autumn (Fall) equinox.
+        /// </summary>
+        /// <param name="Year">The year to calculate the occurrence for. Note that this method refers to "Southward Equinox" instead of "Fall or Autumn equinox" to avoid a northern hemisphere-specific bias.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The date in Dynamical time when the Southward Equinox occurs.</returns>
         public static double SouthwardEquinox(long Year, bool bHighPrecision)
         {
             //calculate the approximate date
@@ -103,6 +124,12 @@ namespace AASharp
             return JDE;
         }
 
+        /// <summary>
+        /// Calculates the date of Winter Solstice.
+        /// </summary>
+        /// <param name="Year">The year to calculate the occurrence for. Note that this method refers to "Southern Solstice" instead of "Winter Solstice" to avoid a northern hemisphere-specific bias.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The date in Dynamical time when the sun reaches its lowest relative to the celestial equator and appears directly over the Tropic of Capricorn.</returns>
         public static double SouthernSolstice(long Year, bool bHighPrecision)
         {
             //calculate the approximate date
@@ -136,6 +163,10 @@ namespace AASharp
             return JDE;
         }
 
+        /// <param name="Year">The year to calculate for.</param>
+        /// <param name="bNorthernHemisphere">true to indicate the observer is in the northern hemisphere, while false means the southern hemisphere.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The length of the astronomical Spring season in days.</returns>
         public static double LengthOfSpring(long Year, bool bNorthernHemisphere, bool bHighPrecision)
         {
             if (bNorthernHemisphere)
@@ -144,6 +175,10 @@ namespace AASharp
                 return SouthernSolstice(Year, bHighPrecision) - SouthwardEquinox(Year, bHighPrecision);
         }
 
+        /// <param name="Year">The year to calculate for.</param>
+        /// <param name="bNorthernHemisphere">true to indicate the observer is in the northern hemisphere, while false means the southern hemisphere.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The length of the astronomical Summer season in days.</returns>
         public static double LengthOfSummer(long Year, bool bNorthernHemisphere, bool bHighPrecision)
         {
             if (bNorthernHemisphere)
@@ -155,6 +190,10 @@ namespace AASharp
             } 
         }
 
+        /// <param name="Year">The year to calculate for.</param>
+        /// <param name="bNorthernHemisphere">true to indicate the observer is in the northern hemisphere, while false means the southern hemisphere.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The length of the astronomical Autumn season in days.</returns>
         public static double LengthOfAutumn(long Year, bool bNorthernHemisphere, bool bHighPrecision)
         {
             if (bNorthernHemisphere)
@@ -163,6 +202,10 @@ namespace AASharp
                 return NorthernSolstice(Year, bHighPrecision) - NorthwardEquinox(Year, bHighPrecision);
         }
 
+        /// <param name="Year">The year to calculate for.</param>
+        /// <param name="bNorthernHemisphere">true to indicate the observer is in the northern hemisphere, while false means the southern hemisphere.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>The length of the astronomical Winter season in days.</returns>
         public static double LengthOfWinter(long Year, bool bNorthernHemisphere, bool bHighPrecision)
         {
             if (bNorthernHemisphere)

--- a/Src/AASharp/AASEquinoxesAndSolstices2.cs
+++ b/Src/AASharp/AASEquinoxesAndSolstices2.cs
@@ -2,8 +2,16 @@ using System.Collections.Generic;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class uses interpolation to calculate the same details as those provided with the existing AASEquinoxesAndSolstices class.
+    /// </summary>
     public static class AASEquinoxesAndSolstices2
     {
+        /// <param name="StartJD">The Julian Day corresponding to the Dynamical Time for the date when you want to start the calculation for.</param>
+        /// <param name="EndJD">The Julian Day corresponding to the Dynamical Time for the date when you want to end the calculation for.</param>
+        /// <param name="StepInterval">The step interval in fractions of days to do the calculation for. The default value of 0.007 corresponds to roughly 10 minutes which is a reasonable tradeoff between performance and accuracy.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>A list of instances of the class AASEquinoxSolsticeDetails2.</returns>
         public static List<AASEquinoxSolsticeDetails2> Calculate(double StartJD, double EndJD, double StepInterval = 0.007, bool bHighPrecision = false)
         {
             //What will be the return value

--- a/Src/AASharp/AASFK5.cs
+++ b/Src/AASharp/AASFK5.cs
@@ -2,8 +2,15 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms to convert to the FK5 standard reference frame. This refers to parts of Chapter 26 and 32 in the book.
+    /// </summary>
     public static class AASFK5
     {
+        /// <param name="Longitude">The VSOP heliocentric longitude in degrees.</param>
+        /// <param name="Latitude">The VSOP heliocentric latitude in degrees.</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The correction in degrees to convert a VSOP heliocentric longitude to the FK5 reference frame.</returns>
         public static double CorrectionInLongitude(double Longitude, double Latitude, double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -17,6 +24,9 @@ namespace AASharp
             return AASCoordinateTransformation.DMSToDegrees(0, 0, value);
         }
 
+        /// <param name="Longitude">The VSOP heliocentric longitude in degrees.</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The correction in degrees to convert a VSOP heliocentric latitude to the FK5 reference frame.</returns>
         public static double CorrectionInLatitude(double Longitude, double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -29,6 +39,8 @@ namespace AASharp
             return AASCoordinateTransformation.DMSToDegrees(0, 0, value);
         }
 
+        /// <param name="value">The geometric rectangular ecliptical coordinates of the object (e.g. the Sun) to convert from the dynamical reference frame (VSOP) to the equatorial FK5 J2000 reference frame.</param>
+        /// <returns>A class containing the converted equatorial FK5 J2000 reference frame coordinates.</returns>
         public static AAS3DCoordinate ConvertVSOPToFK5J2000(AAS3DCoordinate value)
         {
             AAS3DCoordinate result = new AAS3DCoordinate
@@ -41,6 +53,8 @@ namespace AASharp
             return result;
         }
 
+        /// <param name="value">The geometric rectangular ecliptical coordinates of the object (e.g. the Sun) to convert from the dynamical reference frame (VSOP) to the equatorial FK5 B1950 reference frame.</param>
+        /// <returns>A class containing the converted equatorial FK5 B1950 reference frame coordinates.</returns>
         public static AAS3DCoordinate ConvertVSOPToFK5B1950(AAS3DCoordinate value)
         {
             AAS3DCoordinate result = new AAS3DCoordinate
@@ -53,6 +67,9 @@ namespace AASharp
             return result;
         }
 
+        /// <param name="value">The geometric rectangular ecliptical coordinates of the object (e.g. the Sun) to convert from the dynamical reference frame (VSOP) to the equatorial FK5 reference frame of JDEquinox.</param>
+        /// <param name="JDEquinox">The Julian day for which equatorial coordinates should be calculated for.</param>
+        /// <returns>A class containing the converted equatorial FK5 reference frame coordinates.</returns>
         public static AAS3DCoordinate ConvertVSOPToFK5AnyEquinox(AAS3DCoordinate value, double JDEquinox)
         {
             double t = (JDEquinox - 2451545.0) / 36525;

--- a/Src/AASharp/AASGalileanMoonDetail.cs
+++ b/Src/AASharp/AASGalileanMoonDetail.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Instances of this class are held by the AASGalileanMoonsDetails class.
+    /// </summary>
     public class AASGalileanMoonDetail
     {
         public AASGalileanMoonDetail()
@@ -8,16 +11,49 @@ namespace AASharp
             ApparentRectangularCoordinates = new AAS3DCoordinate();
         }
 
+        /// <summary>
+        /// The mean longitude of the moon in degrees.
+        /// </summary>
         public double MeanLongitude { get; set; }
+        /// <summary>
+        /// The true longitude of the moon in degrees.
+        /// </summary>
         public double TrueLongitude { get; set; }
+        /// <summary>
+        /// The tropical longitude of the moon in degrees.
+        /// </summary>
         public double TropicalLongitude { get; set; }
+        /// <summary>
+        /// The latitude in degrees of the moon with respect to Jupiter's equatorial plane.
+        /// </summary>
         public double EquatorialLatitude { get; set; }
+        /// <summary>
+        /// The radius vector of the moon in equatorial radii of Jupiter.
+        /// </summary>
         public double r { get; set; }
+        /// <summary>
+        /// The true 3D rectangular coordinates of the moon.
+        /// </summary>
         public AAS3DCoordinate TrueRectangularCoordinates { get; set; }
+        /// <summary>
+        /// The apparent 3D rectangular coordinates of the moon.
+        /// </summary>
         public AAS3DCoordinate ApparentRectangularCoordinates { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is in front of Jupiter as viewed from the Earth otherwise false.
+        /// </summary>
         public bool bInTransit { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is behind Jupiter as viewed from the Earth otherwise false.
+        /// </summary>
         public bool bInOccultation { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is behind Jupiter as viewed from the Sun otherwise false.
+        /// </summary>
         public bool bInEclipse { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is in front of Jupiter as viewed from the Earth otherwise false.
+        /// </summary>
         public bool bInShadowTransit { get; set; }
     }
 }

--- a/Src/AASharp/AASGalileanMoons.cs
+++ b/Src/AASharp/AASGalileanMoons.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the positions of the Galilean moons of Jupiter. This refers to Chapter 44 in the book.
+    /// </summary>
     public static class AASGalileanMoons
     {
         private static AASGalileanMoonsDetails CalculateHelper(double JD, double sunlongrad, double betarad, double R, bool bHighPrecision)
@@ -474,7 +477,10 @@ namespace AASharp
 
             return details;
         }
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance to the AASGalileanMoonsDetails class with details.</returns>
         public static AASGalileanMoonsDetails Calculate(double JD, bool bHighPrecision)
         {
             //Calculate the position of the Sun

--- a/Src/AASharp/AASGalileanMoonsDetails.cs
+++ b/Src/AASharp/AASGalileanMoonsDetails.cs
@@ -1,5 +1,9 @@
 namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASGalileanMoons.Calculate method.
+    /// It returns separate details for the moons Io, Europa, Ganymede, Callisto.
+    /// </summary>
     public class AASGalileanMoonsDetails
     {
         public AASGalileanMoonsDetails()
@@ -10,9 +14,21 @@ namespace AASharp
             Satellite4 = new AASGalileanMoonDetail();
         }
 
+        /// <summary>
+        /// Details of the moon Io
+        /// </summary>
         public AASGalileanMoonDetail Satellite1 { get; set; }
+        /// <summary>
+        /// Details of the moon Europa
+        /// </summary>
         public AASGalileanMoonDetail Satellite2 { get; set; }
+        /// <summary>
+        /// Details of the moon Ganymede
+        /// </summary>
         public AASGalileanMoonDetail Satellite3 { get; set; }
+        /// <summary>
+        /// Details of the moon Callisto
+        /// </summary>
         public AASGalileanMoonDetail Satellite4 { get; set; }
     }
 }

--- a/Src/AASharp/AASGlobe.cs
+++ b/Src/AASharp/AASGlobe.cs
@@ -2,8 +2,14 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides some basic algorithms related to the figure of the Earth's surface.
+    /// </summary>
     public static class AASGlobe
     {
+        /// <param name="GeographicalLatitude">The latitude of the position in degrees.</param>
+        /// <param name="Height">The observer's height above sea level in meters</param>
+        /// <returns>A numeric value of your position relative to the centre of the earth expressed in units of the equatorial radius. For more information refer to the diagram on Page 81.</returns>
         public static double RhoSinThetaPrime(double GeographicalLatitude, double Height)
         {
             GeographicalLatitude = AASCoordinateTransformation.DegreesToRadians(GeographicalLatitude);
@@ -12,6 +18,9 @@ namespace AASharp
             return 0.99664719 * Math.Sin(U) + (Height / 6378140 * Math.Sin(GeographicalLatitude));
         }
 
+        /// <param name="GeographicalLatitude">The latitude of the position in degrees.</param>
+        /// <param name="Height">The observer's height above sea level in meters</param>
+        /// <returns>A numeric value of your position relative to the centre of the earth expressed in units of the equatorial radius. For more information refer to the diagram on Page 81.</returns>
         public static double RhoCosThetaPrime(double GeographicalLatitude, double Height)
         {
             //Convert from degress to radians
@@ -21,6 +30,8 @@ namespace AASharp
             return Math.Cos(U) + (Height / 6378140 * Math.Cos(GeographicalLatitude));
         }
 
+        /// <param name="GeographicalLatitude">The latitude of the position in degrees.</param>
+        /// <returns>The radius of parallel of latitude expressed in kilometres.</returns>
         public static double RadiusOfParallelOfLatitude(double GeographicalLatitude)
         {
             //Convert from degress to radians
@@ -30,6 +41,8 @@ namespace AASharp
             return (6378.14 * Math.Cos(GeographicalLatitude)) / (Math.Sqrt(1 - 0.0066943847614084 * sinGeo * sinGeo));
         }
 
+        /// <param name="GeographicalLatitude">The latitude of the position in degrees.</param>
+        /// <returns>The radius of curvature of latitude expressed in kilometres.</returns>
         public static double RadiusOfCurvature(double GeographicalLatitude)
         {
             //Convert from degress to radians
@@ -39,6 +52,11 @@ namespace AASharp
             return (6378.14 * (1 - 0.0066943847614084)) / Math.Pow((1 - 0.0066943847614084 * sinGeo * sinGeo), 1.5);
         }
 
+        /// <param name="GeographicalLatitude1">The latitude of the first point in degrees.</param>
+        /// <param name="GeographicalLongitude1">The longitude of the first point in degrees (Positive west, negative east from Greenwich).</param>
+        /// <param name="GeographicalLatitude2">The latitude of the second point in degrees.</param>
+        /// <param name="GeographicalLongitude2">The longitude of the second point in degrees (Positive west, negative east from Greenwich).</param>
+        /// <returns>The shortest distance between two known points on the surface of the Earth expressed in kilometres.</returns>
         public static double DistanceBetweenPoints(double GeographicalLatitude1, double GeographicalLongitude1, double GeographicalLatitude2, double GeographicalLongitude2)
         {
             //Convert from degress to radians

--- a/Src/AASharp/AASIlluminatedFraction.cs
+++ b/Src/AASharp/AASIlluminatedFraction.cs
@@ -2,14 +2,28 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms to calculate a planet's phase angle, illuminated fraction and magnitude. This refers to Chapter 41 in the book.
+    /// </summary>
     public static class AASIlluminatedFraction
     {
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="R">The distance of the Sun from the Earth in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The phase angle in degrees.</returns>
         public static double PhaseAngle(double r, double R, double Delta)
         {
             //Return the result
             return AASCoordinateTransformation.MapTo0To360Range(AASCoordinateTransformation.RadiansToDegrees(Math.Acos((r * r + Delta * Delta - R * R) / (2 * r * Delta))));
         }
 
+        /// <param name="R">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="R0">The distance of the Sun from the Earth in astronomical units.</param>
+        /// <param name="B">The planet's heliocentric latitude in degrees.</param>
+        /// <param name="L">The planet's heliocentric longitude in degrees.</param>
+        /// <param name="L0">The heliocentric latitude of the Earth in degrees.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The phase angle in degrees.</returns>
         public static double PhaseAngle(double R, double R0, double B, double L, double L0, double Delta)
         {
             //Convert from degrees to radians
@@ -21,6 +35,13 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(AASCoordinateTransformation.RadiansToDegrees(Math.Acos((R - R0 * Math.Cos(B) * Math.Cos(L - L0)) / Delta)));
         }
 
+        /// <param name="x">The geocentric rectangular ecliptical X coordinate of the object.</param>
+        /// <param name="y">The geocentric rectangular ecliptical Y coordinate of the object.</param>
+        /// <param name="z">The geocentric rectangular ecliptical Z coordinate of the object.</param>
+        /// <param name="B">The planet's heliocentric latitude in degrees.</param>
+        /// <param name="L">The planet's heliocentric longitude in degrees.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The phase angle in degrees.</returns>
         public static double PhaseAngleRectangular(double x, double y, double z, double B, double L, double Delta)
         {
             //Convert from degrees to radians
@@ -32,6 +53,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(AASCoordinateTransformation.RadiansToDegrees(Math.Acos((x * cosB * Math.Cos(L) + y * cosB * Math.Sin(L) + z * Math.Sin(B)) / Delta)));
         }
 
+        /// <param name="PhaseAngle">The planet's phase angle in degrees.</param>
+        /// <returns>The phase angle in degrees.</returns>
         public static double IlluminatedFraction(double PhaseAngle)
         {
             //Convert from degrees to radians
@@ -41,32 +64,71 @@ namespace AASharp
             return (1 + Math.Cos(PhaseAngle)) / 2;
         }
 
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="R">The distance of the Sun from the Earth in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The phase angle in degrees.</returns>
         public static double IlluminatedFraction(double r, double R, double Delta)
         {
             return (((r + Delta) * (r + Delta) - R * R) / (4 * r * Delta));
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double MercuryMagnitudeMuller(double r, double Delta, double i)
         {
             double I_50 = i - 50;
             return 1.16 + 5 * Math.Log10(r * Delta) + 0.02838 * I_50 + 0.0001023 * I_50 * I_50;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double VenusMagnitudeMuller(double r, double Delta, double i)
         {
             return -4.00 + 5 * Math.Log10(r * Delta) + 0.01322 * i + 0.0000004247 * i * i * i;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double MarsMagnitudeMuller(double r, double Delta, double i)
         {
             return -1.3 + 5 * Math.Log10(r * Delta) + 0.01486 * i;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double JupiterMagnitudeMuller(double r, double Delta)
         {
             return -8.93 + 5 * Math.Log10(r * Delta);
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="DeltaU">The difference between the Saturnicentric longitudes of the Sun and the Earth, measured in the plane o the ring in degrees.</param>
+        /// <param name="B">The Saturnicentric latitude of the Earth referred to the plane of the ring in degrees</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double SaturnMagnitudeMuller(double r, double Delta, double DeltaU, double B)
         {
             //Convert from degrees to radians
@@ -76,16 +138,35 @@ namespace AASharp
             return -8.68 + 5 * Math.Log10(r * Delta) + 0.044 * Math.Abs(DeltaU) - 2.60 * Math.Sin(Math.Abs(B)) + 1.25 * sinB * sinB;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double UranusMagnitudeMuller(double r, double Delta)
         {
             return -6.85 + 5 * Math.Log10(r * Delta);
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided by G. Muller.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double NeptuneMagnitudeMuller(double r, double Delta)
         {
             return -7.05 + 5 * Math.Log10(r * Delta);
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double MercuryMagnitudeAA(double r, double Delta, double i)
         {
             double i2 = i * i;
@@ -94,6 +175,13 @@ namespace AASharp
             return -0.42 + 5 * Math.Log10(r * Delta) + 0.0380 * i - 0.000273 * i2 + 0.000002 * i3;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double VenusMagnitudeAA(double r, double Delta, double i)
         {
             double i2 = i * i;
@@ -102,16 +190,38 @@ namespace AASharp
             return -4.40 + 5 * Math.Log10(r * Delta) + 0.0009 * i + 0.000239 * i2 - 0.00000065 * i3;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double MarsMagnitudeAA(double r, double Delta, double i)
         {
             return -1.52 + 5 * Math.Log10(r * Delta) + 0.016 * i;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="i">The planet's phase angle in degrees.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double JupiterMagnitudeAA(double r, double Delta, double i)
         {
             return -9.40 + 5 * Math.Log10(r * Delta) + 0.005 * i;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <param name="DeltaU">The difference between the Saturnicentric longitudes of the Sun and the Earth, measured in the plane o the ring in degrees.</param>
+        /// <param name="B">The Saturnicentric latitude of the Earth referred to the plane of the ring in degrees</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double SaturnMagnitudeAA(double r, double Delta, double DeltaU, double B)
         {
             //Convert from degrees to radians
@@ -121,16 +231,34 @@ namespace AASharp
             return -8.88 + 5 * Math.Log10(r * Delta) + 0.044 * Math.Abs(DeltaU) - 2.60 * Math.Sin(Math.Abs(B)) + 1.25 * sinB * sinB;
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double UranusMagnitudeAA(double r, double Delta)
         {
             return -7.19 + 5 * Math.Log10(r * Delta);
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double NeptuneMagnitudeAA(double r, double Delta)
         {
             return -6.87 + 5 * Math.Log10(r * Delta);
         }
 
+        /// <summary>
+        /// Uses the formula to calculate the magnitude as provided in the Astronomical Almanac.
+        /// </summary>
+        /// <param name="r">The planet's distance to the Sun in astronomical units.</param>
+        /// <param name="Delta">The planet's distance from the Earth in astronomical units.</param>
+        /// <returns>The magnitude of the planet.</returns>
         public static double PlutoMagnitudeAA(double r, double Delta)
         {
             return -1.00 + 5 * Math.Log10(r * Delta);

--- a/Src/AASharp/AASInterpolate.cs
+++ b/Src/AASharp/AASInterpolate.cs
@@ -2,8 +2,19 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms for interpolation. This refers to Chapter 3 in the book.
+    /// </summary>
     public static class AASInterpolate
     {
+        /// <summary>
+        /// Interpolates a function from 3 points.
+        /// </summary>
+        /// <param name="n">The interpolating factor.</param>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <returns>The interpolated Y value.</returns>
         public static double Interpolate(double n, double Y1, double Y2, double Y3)
         {
             double a = Y2 - Y1;
@@ -13,6 +24,16 @@ namespace AASharp
             return Y2 + n / 2 * (a + b + n * c);
         }
 
+        /// <summary>
+        /// Interpolates a function from 5 points.
+        /// </summary>
+        /// <param name="n">The interpolating factor.</param>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <param name="Y4">The fourth Y value to interpolate from.</param>
+        /// <param name="Y5">The fifth Y value to interpolate from.</param>
+        /// <returns>The interpolated Y value.</returns>
         public static double Interpolate(double n, double Y1, double Y2, double Y3, double Y4, double Y5)
         {
             double A = Y2 - Y1;
@@ -33,11 +54,27 @@ namespace AASharp
             return Y3 + n * ((B + C) / 2 - (H + J) / 12) + N2 * (F / 2 - K / 24) + N3 * ((H + J) / 12) + N4 * (K / 24);
         }
 
+        /// <summary>
+        /// Interpolates a function to the middle location where 4 evenly spaced values are provided.
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <param name="Y4">The fourth Y value to interpolate from.</param>
+        /// <returns>The interpolated Y value.</returns>
         public static double InterpolateToHalves(double Y1, double Y2, double Y3, double Y4)
         {
             return (9 * (Y2 + Y3) - Y1 - Y4) / 16;
         }
 
+        /// <summary>
+        /// Interpolates a function using Lagrange's formula where an arbitrary number of values are provided.
+        /// </summary>
+        /// <param name="X">The X value to interpolate for.</param>
+        /// <param name="n">The size of the pX and pY arrays.</param>
+        /// <param name="pX">Pointer to the array of X coordinates to interpolate from.</param>
+        /// <param name="pY">Pointer to the array of Y coordinates to interpolate from.</param>
+        /// <returns>The interpolated Y value.</returns>
         public static double LagrangeInterpolate(double X, int n, double[] pX, double[] pY)
         {
             double V = 0;
@@ -56,6 +93,14 @@ namespace AASharp
             return V;
         }
 
+        /// <summary>
+        /// Interpolates a function to determine where the function reaches an extremum.
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <param name="nm">Upon return will contain the corresponding value of the argument X where the extremum is reached.</param>
+        /// <returns>The extreme Y value.</returns>
         public static double Extremum(double Y1, double Y2, double Y3, ref double nm)
         {
             double a = Y2 - Y1;
@@ -68,6 +113,16 @@ namespace AASharp
             return (Y2 - ((ab * ab) / (8 * c)));
         }
 
+        /// <summary>
+        /// Interpolates a function to determine where the function reaches an extremum.
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <param name="Y4">The fourth Y value to interpolate from.</param>
+        /// <param name="Y5">The fifth Y value to interpolate from.</param>
+        /// <param name="nm">Upon return will contain the corresponding value of the argument X where the extremum is reached.</param>
+        /// <returns>The extreme Y value.</returns>
         public static double Extremum(double Y1, double Y2, double Y3, double Y4, double Y5, ref double nm)
         {
             double A = Y2 - Y1;
@@ -98,6 +153,13 @@ namespace AASharp
             return Interpolate(nm, Y1, Y2, Y3, Y4, Y5);
         }
 
+        /// <summary>
+        /// Finds where a function reaches zero when the function is "almost a straight line".
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <returns>The value of the argument X for which the function y becomes zero.</returns>
         public static double Zero(double Y1, double Y2, double Y3)
         {
             double a = Y2 - Y1;
@@ -119,6 +181,15 @@ namespace AASharp
             return n0;
         }
 
+        /// <summary>
+        /// Finds where a function reaches zero when the function is "almost a straight line".
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <param name="Y4">The fourth Y value to interpolate from.</param>
+        /// <param name="Y5">The fifth Y value to interpolate from.</param>
+        /// <returns>The value of the argument X for which the function y becomes zero.</returns>
         public static double Zero(double Y1, double Y2, double Y3, double Y4, double Y5)
         {
             double A = Y2 - Y1;
@@ -151,7 +222,13 @@ namespace AASharp
             return n0;
         }
 
-
+        /// <summary>
+        /// Finds where a function reaches zero when the curvature of the function is important.
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <returns>The value of the argument X for which the function y becomes zero.</returns>
         public static double Zero2(double Y1, double Y2, double Y3)
         {
             double a = Y2 - Y1;
@@ -174,6 +251,15 @@ namespace AASharp
             return n0;
         }
 
+        /// <summary>
+        /// Finds where a function reaches zero when the curvature of the function is important.
+        /// </summary>
+        /// <param name="Y1">The first Y value to interpolate from.</param>
+        /// <param name="Y2">The second Y value to interpolate from.</param>
+        /// <param name="Y3">The third Y value to interpolate from.</param>
+        /// <param name="Y4">The fourth Y value to interpolate from.</param>
+        /// <param name="Y5">The fifth Y value to interpolate from.</param>
+        /// <returns>The value of the argument X for which the function y becomes zero.</returns>
         public static double Zero2(double Y1, double Y2, double Y3, double Y4, double Y5)
         {
             double A = Y2 - Y1;

--- a/Src/AASharp/AASJewishCalendar.cs
+++ b/Src/AASharp/AASJewishCalendar.cs
@@ -1,7 +1,13 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms which convert between the Gregorian, Julian and Jewish calendars. This refers to Chapter 9 in the book.
+    /// </summary>
     public static class AASJewishCalendar
     {
+        /// <param name="Year">The year in the Julian or Gregorian Calendar to calculate Jewish Easter or Pesach for. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="bGregorianCalendar">true to imply a date in the Gregorian Calendar, false means use the Julian Calendar.</param>
+        /// <returns>An instance of the AASCalendarDate class with details.</returns>
         public static AASCalendarDate DateOfPesach(long Year, bool bGregorianCalendar = true)
         {
             //What will be the return value
@@ -41,6 +47,8 @@
             return Pesach;
         }
 
+        /// <param name="Year">The year in the Jewish calendar.</param>
+        /// <returns>true if the specified year is leap otherwise false.</returns>
         public static bool IsLeap(long Year)
         {
             long ymod19 = Year % 19;
@@ -48,6 +56,8 @@
             return (ymod19 == 0) || (ymod19 == 3) || (ymod19 == 6) || (ymod19 == 8) || (ymod19 == 11) || (ymod19 == 14) || (ymod19 == 17);
         }
 
+        /// <param name="Year">The year in the Jewish Calendar.</param>
+        /// <returns>The number of days in the specified Jewish Year</returns>
         public static long DaysInYear(long Year)
         {
             //Find the previous civil year corresponding to the specified jewish year

--- a/Src/AASharp/AASJupiter.cs
+++ b/Src/AASharp/AASJupiter.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Jupiter. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASJupiter
     {
         #region coefficients        
@@ -575,9 +578,12 @@ namespace AASharp
           new VSOP87Coefficient( 2,  4.13, 1059.38 ),
           new VSOP87Coefficient( 2,  5.49, 1066.50 )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -635,6 +641,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -692,6 +701,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASKepler.cs
+++ b/Src/AASharp/AASKepler.cs
@@ -2,8 +2,15 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for the solution of Kepler's equation. This refers to Chapter 30 in the book.
+    /// </summary>
     public static class AASKepler
     {
+        /// <param name="M">The mean anomaly in degrees.</param>
+        /// <param name="e">The eccentricity of the orbit</param>
+        /// <param name="nIterations">The method uses the third method to solve the equation. This uses a binary chop to find the solution. The default value of 53 is the number of iterations required to obtain the accuracy of the standard Visual C "double".</param>
+        /// <returns>The Eccentric anomaly in degrees (i.e. the solution to Kepler's equation).</returns>
         public static double Calculate(double M, double e, int nIterations = 53)
         {
             //Convert from degrees to radians

--- a/Src/AASharp/AASLunarEclipseDetails.cs
+++ b/Src/AASharp/AASLunarEclipseDetails.cs
@@ -1,18 +1,57 @@
 namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASEclipses.CalculateLunar
+    /// </summary>
     public class AASLunarEclipseDetails
     {
+        /// <summary>
+        /// true if a lunar eclipse occurs at this Full Moon.
+        /// </summary>
         public bool bEclipse { get; set; }
+        /// <summary>
+        /// The moons argument of Latitude in degrees at the time of the eclipse.
+        /// </summary>
         public double F { get; set; }
+        /// <summary>
+        /// The gamma term for the eclipse.
+        /// </summary>
         public double gamma { get; set; }
+        /// <summary>
+        /// The semi-duration of the partial phase in the penumbra.
+        /// </summary>
         public double PartialPhasePenumbraSemiDuration { get; set; }
+        /// <summary>
+        /// The semi-duration of the eclipse during the partial phase.
+        /// </summary>
         public double PartialPhaseSemiDuration { get; set; }
+        /// <summary>
+        /// The magnitude of the eclipse if the eclipse is penumbral.
+        /// </summary>
         public double PenumbralMagnitude { get; set; }
+        /// <summary>
+        /// The radii of the eclipse for the penumbra in equatorial earth radii.
+        /// </summary>
         public double PenumbralRadii { get; set; }
+        /// <summary>
+        /// The date in Dynamical time of maximum eclipse.
+        /// </summary>
         public double TimeOfMaximumEclipse { get; set; }
+        /// <summary>
+        /// The semi-duration of the eclipse during the total phase.
+        /// </summary>
         public double TotalPhaseSemiDuration { get; set; }
+        /// <summary>
+        /// The U term for the eclipse.
+        /// </summary>
         public double u { get; set; }
+        /// <summary>
+        /// The magnitude of the eclipse if the eclipse is umbral.
+        /// </summary>
         public double UmbralMagnitude { get; set; }
+        /// <summary>
+        /// The radii of the eclipse for the umbra in equatorial earth radii.
+        /// </summary>
         public double UmbralRadii { get; set; }
     }
 }

--- a/Src/AASharp/AASMars.cs
+++ b/Src/AASharp/AASMars.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Mars. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASMars
     {
         #region coefficients
@@ -372,9 +375,12 @@ namespace AASharp
             new VSOP87Coefficient( 6,  4.46, 10021.84 ),
             new VSOP87Coefficient( 2,  4.84, 13362.45 )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -432,6 +438,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -482,6 +491,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASMath.cs
+++ b/Src/AASharp/AASMath.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// Additional mathematical operations.
+    /// </summary>
     internal static class AASMath
     {
         /// <summary>
@@ -9,9 +12,9 @@ namespace AASharp
         /// Break into fractional and integral parts
         /// Breaks value into an integral and a fractional part.
         /// </summary>
-        /// <param name="value"></param>
-        /// <param name="integralPart"></param>
-        /// <returns></returns>
+        /// <param name="value">The value to break apart.</param>
+        /// <param name="integralPart">This will hold the integral part</param>
+        /// <returns>The fractional part</returns>
         internal static double modF(double value, ref double integralPart)
         {
             integralPart = Math.Floor(value);

--- a/Src/AASharp/AASMercury.cs
+++ b/Src/AASharp/AASMercury.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Mercury. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASMercury
     {
         #region coefficient
@@ -220,9 +223,12 @@ namespace AASharp
             new VSOP87Coefficient( 5,  4.44, 104351.61 ),
             new VSOP87Coefficient( 2,  1.21, 130439.52 ) 
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision) 
@@ -280,6 +286,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision) 
@@ -330,6 +339,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASMoon.cs
+++ b/Src/AASharp/AASMoon.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms which obtain the position of the Moon. This refers to Chapter 47 in the book.
+    /// </summary>
     public static class AASMoon
     {
         #region coefficients
@@ -261,9 +264,11 @@ namespace AASharp
           115,
           107
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the Moon in degrees.</returns>
         public static double MeanLongitude(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -273,6 +278,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(218.3164477 + 481267.88123421 * T - 0.0015786 * Tsquared + Tcubed / 538841 - T4 / 65194000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean elongation of the Moon in degrees.</returns>
         public static double MeanElongation(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -282,6 +289,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(297.8501921 + 445267.1114034 * T - 0.0018819 * Tsquared + Tcubed / 545868 - T4 / 113065000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean anomaly of the Moon in degrees.</returns>
         public static double MeanAnomaly(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -291,6 +300,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(134.9633964 + 477198.8675055 * T + 0.0087414 * Tsquared + Tcubed / 69699 - T4 / 14712000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the argument of latitude (mean distance of the Moon from its ascending node) in degrees.</returns>
         public static double ArgumentOfLatitude(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -300,6 +311,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(93.2720950 + 483202.0175233 * T - 0.0036539 * Tsquared - Tcubed / 3526000 + T4 / 863310000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date.</returns>
         public static double EclipticLongitude(double JD)
         {
             double Ldash = MeanLongitude(JD);
@@ -349,6 +362,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(LdashDegrees + SigmaL/1000000 + NutationInLong/3600);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in kilometres.</returns>
         public static double RadiusVector(double JD)
         {
             double D = MeanElongation(JD);
@@ -379,6 +394,8 @@ namespace AASharp
             return 385000.56 + SigmaR/1000;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date.</returns>
         public static double EclipticLatitude(double JD)
         {
             double Ldash = MeanLongitude(JD);
@@ -427,16 +444,22 @@ namespace AASharp
             return SigmaB/1000000;
         }
 
+        /// <param name="RadiusVector">The distance to the object (e.g. Moon) in kilometres.</param>
+        /// <returns>the parallax of the object in degrees.</returns>
         public static double RadiusVectorToHorizontalParallax(double RadiusVector)
         {
             return AASCoordinateTransformation.RadiansToDegrees(Math.Asin(6378.14 / RadiusVector));
         }
 
+        /// <param name="Parallax">the parallax of the object (e.g. Moon) in degrees.</param>
+        /// <returns>The distance to the object in kilometres.</returns>
         public static double HorizontalParallaxToRadiusVector(double Parallax)
         {
             return 6378.14 / Math.Sin(AASCoordinateTransformation.DegreesToRadians(Parallax));
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the ascending node of the Moon in degrees.</returns>
         public static double MeanLongitudeAscendingNode(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -446,6 +469,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(125.0445479 - 1934.1362891 * T + 0.0020754 * Tsquared + Tcubed / 467441 - T4 / 60616000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude of the perigee of the lunar orbit in degrees.</returns>
         public static double MeanLongitudePerigee(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -455,6 +480,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(83.3532465 + 4069.0137287 * T - 0.0103200 * Tsquared - Tcubed / 80053 + T4 / 18999000);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the true longitude of the ascending node of the lunar orbit in degrees.</returns>
         public static double TrueLongitudeAscendingNode(double JD)
         {
             double TrueAscendingNode = MeanLongitudeAscendingNode(JD);

--- a/Src/AASharp/AASMoonIlluminatedFraction.cs
+++ b/Src/AASharp/AASMoonIlluminatedFraction.cs
@@ -2,8 +2,16 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides algorithms for the Moon's elongation, phase angle and illuminated fraction. This refers to Chapter 48 in the book.
+    /// </summary>
     public static class AASMoonIlluminatedFraction
     {
+        /// <param name="ObjectAlpha">The geocentric right ascension of the object (e.g. the Moon) expressed as an hour angle.</param>
+        /// <param name="ObjectDelta">The geocentric declination of the object (e.g. the Moon) in degrees.</param>
+        /// <param name="SunAlpha">The geocentric right ascension of the Sun expressed as an hour angle.</param>
+        /// <param name="SunDelta">The geocentric declination of the Sun in degrees.</param>
+        /// <returns>the elongation of the object from the Sun</returns>
         public static double GeocentricElongation(double ObjectAlpha, double ObjectDelta, double SunAlpha, double SunDelta)
         {
             //Convert the RA's to radians
@@ -18,6 +26,10 @@ namespace AASharp
             return AASCoordinateTransformation.RadiansToDegrees(Math.Acos(Math.Sin(SunDelta) * Math.Sin(ObjectDelta) + Math.Cos(SunDelta) * Math.Cos(ObjectDelta) * Math.Cos(SunAlpha - ObjectAlpha)));
         }
 
+        /// <param name="GeocentricElongation">The geocentric elongation in degrees.</param>
+        /// <param name="EarthObjectDistance">The distance in astronomical units between the Earth and the object (the Moon)</param>
+        /// <param name="EarthSunDistance">The distance in astronomical units between the Earth and the Sun</param>
+        /// <returns>the phase angle in degrees.</returns>
         public static double PhaseAngle(double GeocentricElongation, double EarthObjectDistance, double EarthSunDistance)
         {
             //Convert from degrees to radians
@@ -27,6 +39,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(AASCoordinateTransformation.RadiansToDegrees(Math.Atan2(EarthSunDistance * Math.Sin(GeocentricElongation), EarthObjectDistance - EarthSunDistance * Math.Cos(GeocentricElongation))));
         }
 
+        /// <param name="PhaseAngle">The phase angle in degrees.</param>
+        /// <returns>the illuminated fraction (a value form 0 to 1).</returns>
         public static double IlluminatedFraction(double PhaseAngle)
         {
             //Convert from degrees to radians
@@ -36,6 +50,11 @@ namespace AASharp
             return (1 + Math.Cos(PhaseAngle)) / 2;
         }
 
+        /// <param name="Alpha0">The geocentric right ascension of the Sun expressed as an hour angle.</param>
+        /// <param name="Delta0">The geocentric declination of the Sun in degrees.</param>
+        /// <param name="Alpha">The geocentric right ascension of the object (e.g. the Moon) expressed as an hour angle.</param>
+        /// <param name="Delta">The geocentric declination of the object (e.g. the Moon) in degrees.</param>
+        /// <returns>the position angle of the midpoint of the illuminated limb of the object (the Moon) in degrees.</returns>
         public static double PositionAngle(double Alpha0, double Delta0, double Alpha, double Delta)
         {
             //Convert to radians

--- a/Src/AASharp/AASMoonMaxDeclinations.cs
+++ b/Src/AASharp/AASMoonMaxDeclinations.cs
@@ -2,13 +2,24 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides algorithms to calculate the times when the Moon reaches its maximum Northerly and Southerly declinations. This refers to Chapter 52 in the book.
+    /// </summary>
     public class AASMoonMaxDeclinations
     {
+        /// <summary>
+        /// Please note that the return value from this method must be rounded to an integer by client code before calling other methods in this class with this K value. Any other value of K will give meaningless values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K (required by the other methods of CAAMoonMaxDeclinations) for calculation of the Moon's max declination.</returns>
         public static double K(double Year)
         {
             return 13.3686 * (Year - 2000.03);
         }
 
+        /// <param name="k">The K value to calculate the max declination for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="bNortherly">true if this is a calculation for a maximum northerly declination, false implies a calculation of the a maximum southerly declination.</param>
+        /// <returns>Returns the date in Dynamical time when the mean maximum declination occurs.</returns>
         public static double MeanGreatestDeclination(double k, bool bNortherly)
         {
             //convert from K to T
@@ -20,6 +31,8 @@ namespace AASharp
             return value + 27.321582247 * k + 0.000119804 * T2 - 0.000000141 * T3;
         }
 
+        /// <param name="k">The K value to calculate the max declination for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the mean maximum declination in degrees.</returns>
         public static double MeanGreatestDeclinationValue(double k)
         {
             //convert from K to T
@@ -27,6 +40,9 @@ namespace AASharp
             return 23.6961 - 0.013004 * T;
         }
 
+        /// <param name="k">The K value to calculate the max declination for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="bNortherly">true if this is a calculation for a maximum northerly declination, false implies a calculation of the a maximum southerly declination.</param>
+        /// <returns>Returns the date in Dynamical time when the true maximum declination occurs.</returns>
         public static double TrueGreatestDeclination(double k, bool bNortherly)
         {
             //convert from K to T
@@ -150,6 +166,9 @@ namespace AASharp
             return MeanGreatestDeclination(k, bNortherly) + DeltaJD;
         }
 
+        /// <param name="k">The K value to calculate the max declination for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="bNortherly">true if this is a calculation for a maximum northerly declination, false implies a calculation of the a maximum southerly declination.</param>
+        /// <returns>Returns the true maximum declination in degrees.</returns>
         public static double TrueGreatestDeclinationValue(double k, bool bNortherly)
         {
             //convert from K to T

--- a/Src/AASharp/AASMoonMaxDeclinations2.cs
+++ b/Src/AASharp/AASMoonMaxDeclinations2.cs
@@ -3,13 +3,25 @@ using System.Collections.Generic;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class uses interpolation to calculate the same details as those provided with the existing AASMoonMaxDeclinations class.
+    /// </summary>
     public static class AASMoonMaxDeclinations2
     {
         public enum Algorithm
         {
+            /// <summary>
+            /// the truncated ELP2000 algorithm
+            /// </summary>
             MeeusTruncated = 0,
         };
 
+        /// <param name="StartJD">The Julian Day corresponding to the Dynamical Time for the date when you want to start the calculation for.</param>
+        /// <param name="EndJD">The Julian Day corresponding to the Dynamical Time for the date when you want to end the calculation for.</param>
+        /// <param name="StepInterval">The step interval in fractions of days to do the calculation for. The default value of 0.007 corresponds to roughly 10 minutes which is a reasonable tradeoff between performance and accuracy.</param>
+        /// <param name="algorithm">An enum class representing the algorithm to use for the calculation. Can be MeeusTruncated which represents the truncated ELP2000 algorithm presented in the book, ELP2000 which uses the full ELP2000 algorithm, ELPMPP02Nominal which uses the ELPMPP02 Nominal fit, ELPMPP02LLR which uses the ELPMPP02 Lunar Laser Ranging fit, ELPMPP02DE405 which uses the ELPMPP02 DE405 fit and ELPMPP02DE406 which uses the ELPMPP02 DE406 fit.</param>
+        /// <returns>An array of AASMoonMaxDeclinationsDetails2 instances with the details.</returns>
+        /// <exception cref="Exception"></exception>
         public static List<AASMoonMaxDeclinationsDetails2> Calculate(double StartJD, double EndJD, double StepInterval = 0.007, Algorithm algorithm = Algorithm.MeeusTruncated)
         {
             //What will be the return value

--- a/Src/AASharp/AASMoonMaxDeclinationsDetails2.cs
+++ b/Src/AASharp/AASMoonMaxDeclinationsDetails2.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Instances of this class are returned as an array by the AASMoonMaxDeclinations2.Calculate method.
+    /// </summary>
     public class AASMoonMaxDeclinationsDetails2
     {
         public enum Type

--- a/Src/AASharp/AASMoonNodes.cs
+++ b/Src/AASharp/AASMoonNodes.cs
@@ -2,13 +2,23 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides algorithms which obtain dates when the Moon passes through its nodes. This refers to Chapter 51 in the book.
+    /// </summary>
     public static class AASMoonNodes
     {
+        /// <summary>
+        /// Please note that the return value from this method must be rounded to an integer or an integer + 0.5 by client code before calling other methods in this class with this K value. Any other value of K will give meaningless values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K (required by the other methods of AASMoonNodes) for calculation of the specified passage thro the node.</returns>
         public static double K(double Year)
         {
             return 13.4223 * (Year - 2000.05);
         }
 
+        /// <param name="k">The K value to calculate the passage thro the node for. This K value must be an integer value or an integer value + 0.5. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified passage thro the node occurs.</returns>
         public static double PassageThroNode(double k)
         {
             //convert from K to T

--- a/Src/AASharp/AASMoonNodes2.cs
+++ b/Src/AASharp/AASMoonNodes2.cs
@@ -3,13 +3,25 @@ using System.Collections.Generic;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class uses interpolation to calculate the same details as those provided with the existing AASMoonNodes class.
+    /// </summary>
     public static class AASMoonNodes2
     {
         public enum Algorithm
         {
+            /// <summary>
+            /// the truncated ELP2000 algorithm
+            /// </summary>
             MeeusTruncated = 0,
         };
 
+        /// <param name="StartJD">The Julian Day corresponding to the Dynamical Time for the date when you want to start the calculation for.</param>
+        /// <param name="EndJD">The Julian Day corresponding to the Dynamical Time for the date when you want to end the calculation for.</param>
+        /// <param name="StepInterval">The step interval in fractions of days to do the calculation for. The default value of 0.007 corresponds to roughly 10 minutes which is a reasonable tradeoff between performance and accuracy.</param>
+        /// <param name="algorithm">An enum class representing the algorithm to use for the calculation. Can be MeeusTruncated which represents the truncated ELP2000 algorithm presented in the book, ELP2000 which uses the full ELP2000 algorithm, ELPMPP02Nominal which uses the ELPMPP02 Nominal fit, ELPMPP02LLR which uses the ELPMPP02 Lunar Laser Ranging fit, ELPMPP02DE405 which uses the ELPMPP02 DE405 fit and ELPMPP02DE406 which uses the ELPMPP02 DE406 fit.</param>
+        /// <returns>An array of AASMoonNodesDetails2 instances with the details.</returns>
+        /// <exception cref="Exception"></exception>
         public static List<AASMoonNodesDetails2> Calculate(double StartJD, double EndJD, double StepInterval = 0.007, Algorithm algorithm = Algorithm.MeeusTruncated)
         {
             //What will be the return value

--- a/Src/AASharp/AASMoonNodesDetails2.cs
+++ b/Src/AASharp/AASMoonNodesDetails2.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Instances of this class are returned by the AASMoonNodes2.Calculate method.
+    /// </summary>
     public class AASMoonNodesDetails2
     {
         public enum Type

--- a/Src/AASharp/AASMoonPerigeeApogee.cs
+++ b/Src/AASharp/AASMoonPerigeeApogee.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides algorithms to calculate the approximate times when the distance between the Earth and the Moon is a minimum (perigee) or a maximum (apogee). This refers to Chapter 50 in the book.
+    /// </summary>
     public static class AASMoonPerigeeApogee
     {
         #region coefficients
@@ -176,15 +179,21 @@ namespace AASharp
             new MoonPerigeeApogeeCoefficient( 6,  -1, 0,  0.014,      0      ),
             new MoonPerigeeApogeeCoefficient( 8,  0,  0,  0.010,      0      )   
         };
-        
-        #endregion
-        
 
+        #endregion
+
+        /// <summary>
+        /// Please note that the return value from this method must be rounded to an integer or an integer + 0.5 by client code before calling other methods in this class with this K value. Any other value of K will give meaningless values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K (required by the other methods of AASMoonPerigeeApogee) for calculation of the specified phase.</returns>
         public static double K(double Year)
         {
             return 13.2555 * (Year - 1999.97);
         }
 
+        /// <param name="k">The K value to calculate the perigee for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the mean perigee occurs.</returns>
         public static double MeanPerigee(double k)
         {
             //convert from K to T
@@ -196,12 +205,16 @@ namespace AASharp
             return 2451534.6698 + 27.55454989 * k - 0.0006691 * Tsquared - 0.000001098 * Tcubed + 0.0000000052 * T4;
         }
 
+        /// <param name="k">The K value to calculate the apogee for. This K value must be an integer value + 0.5. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified mean apogee occurs.</returns>
         public static double MeanApogee(double k)
         {
             //Uses the same formula as MeanPerigee
             return MeanPerigee(k);
         }
 
+        /// <param name="k">The K value to calculate the perigee for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified true perigee occurs.</returns>
         public static double TruePerigee(double k)
         {
             double MeanJD = MeanPerigee(k);
@@ -230,6 +243,8 @@ namespace AASharp
             return MeanJD + Sigma;
         }
 
+        /// <param name="k">The K value to calculate the perigee parallax for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the parallax at the specified perigee in degrees.</returns>
         public static double PerigeeParallax(double k)
         {
             //convert from K to T
@@ -256,6 +271,8 @@ namespace AASharp
             return Parallax / 3600;
         }
 
+        /// <param name="k">The K value to calculate the apogee for. This K value must be an integer value + 0.5. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified true apogee occurs.</returns>
         public static double TrueApogee(double k)
         {
             double MeanJD = MeanApogee(k);
@@ -284,6 +301,8 @@ namespace AASharp
             return MeanJD + Sigma;
         }
 
+        /// <param name="k">The K value to calculate the apogee parallax for. This K value must be an integer value + 0.5. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the parallax at the specified apogee in degrees.</returns>
         public static double ApogeeParallax(double k)
         {
             //convert from K to T

--- a/Src/AASharp/AASMoonPerigeeApogee2.cs
+++ b/Src/AASharp/AASMoonPerigeeApogee2.cs
@@ -3,13 +3,25 @@ using System.Collections.Generic;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class uses interpolation to calculate the same details as those provided with the existing AASMoonPerigeeApogee class.
+    /// </summary>
     public class AASMoonPerigeeApogee2
     {
         public enum Algorithm
         {
+            /// <summary>
+            /// truncated ELP2000 algorithm
+            /// </summary>
             MeeusTruncated = 0,
         };
-    
+
+        /// <param name="StartJD">The Julian Day corresponding to the Dynamical Time for the date when you want to start the calculation for.</param>
+        /// <param name="EndJD">The Julian Day corresponding to the Dynamical Time for the date when you want to end the calculation for.</param>
+        /// <param name="StepInterval">The step interval in fractions of days to do the calculation for. The default value of 0.007 corresponds to roughly 10 minutes which is a reasonable tradeoff between performance and accuracy.</param>
+        /// <param name="algorithm">An enum class representing the algorithm to use for the calculation. Can be MeeusTruncated which represents the truncated ELP2000 algorithm presented in the book, ELP2000 which uses the full ELP2000 algorithm, ELPMPP02Nominal which uses the ELPMPP02 Nominal fit, ELPMPP02LLR which uses the ELPMPP02 Lunar Laser Ranging fit, ELPMPP02DE405 which uses the ELPMPP02 DE405 fit and ELPMPP02DE406 which uses the ELPMPP02 DE406 fit.</param>
+        /// <returns>A list of AASMoonPerigeeApogeeDetails2 instances with details.</returns>
+        /// <exception cref="Exception"></exception>
         public static List<AASMoonPerigeeApogeeDetails2> Calculate(double StartJD, double EndJD, double StepInterval = 0.007, Algorithm algorithm = Algorithm.MeeusTruncated)
         {
             //What will be the return value

--- a/Src/AASharp/AASMoonPerigeeApogeeDetails2.cs
+++ b/Src/AASharp/AASMoonPerigeeApogeeDetails2.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Instances of this class are returned by AASMoonPerigeeApogee2.Calculate method.
+    /// </summary>
     public class AASMoonPerigeeApogeeDetails2
     {
         public enum Type

--- a/Src/AASharp/AASMoonPhases.cs
+++ b/Src/AASharp/AASMoonPhases.cs
@@ -2,13 +2,23 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides algorithms which obtain the dates for the phases of the Moon. This refers to Chapter 49 in the book.
+    /// </summary>
     public static class AASMoonPhases
     {
+        /// <summary>
+        /// Please note that the return value from this method must be rounded to an integer, an integer + 0.25, an integer + 0.5 or an integer + 0.75 by client code before calling other methods in this class with this K value. Any other value of K will give meaningless values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K (required by the other methods of AASMoonPhases) for calculation of the specified phase.</returns>
         public static double K(double Year)
         {
             return 12.3685 * (Year - 2000);
         }
 
+        /// <param name="k">The K value to calculate the phase for. This K value must be an integer value for New Moon, an integer value + 0.25 for First Quarter, an integer value + 0.5 for Full Moon or an integer value + 0.75 fr Last Quarter. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified mean moon phase occurs.</returns>
         public static double MeanPhase(double k)
         {
             //convert from K to T
@@ -20,6 +30,9 @@ namespace AASharp
             return 2451550.09766 + 29.530588861 * k + 0.00015437 * T2 - 0.000000150 * T3 + 0.00000000073 * T4;
         }
 
+        /// <param name="k">The K value to calculate the phase for. This K value must be an integer value for New Moon, an integer value + 0.25 for First Quarter, an integer value + 0.5 for Full Moon or an integer value + 0.75 fr Last Quarter. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified true moon phase occurs.</returns>
+        /// <exception cref="NotSupportedException"></exception>
         public static double TruePhase(double k)
         {
             //What will be the return value

--- a/Src/AASharp/AASMoonPhases2.cs
+++ b/Src/AASharp/AASMoonPhases2.cs
@@ -3,13 +3,25 @@ using System.Collections.Generic;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class uses interpolation to calculate the same details as those provided with the existing AASMoonPhases class.
+    /// </summary>
     public static class AASMoonPhases2
     {
         public enum Algorithm
         {
+            /// <summary>
+            /// the truncated ELP2000 algorithm
+            /// </summary>
             MeeusTruncated = 0
         }
 
+        /// <param name="StartJD">The Julian Day corresponding to the Dynamical Time for the date when you want to start the calculation for.</param>
+        /// <param name="EndJD">The Julian Day corresponding to the Dynamical Time for the date when you want to end the calculation for.</param>
+        /// <param name="StepInterval">The step interval in fractions of days to do the calculation for. The default value of 0.007 corresponds to roughly 10 minutes which is a reasonable tradeoff between performance and accuracy.</param>
+        /// <param name="algorithm">An enum class representing the algorithm to use for the calculation. Can be MeeusTruncated which represents the truncated ELP2000 algorithm presented in the book, ELP2000 which uses the full ELP2000 algorithm, ELPMPP02Nominal which uses the ELPMPP02 Nominal fit, ELPMPP02LLR which uses the ELPMPP02 Lunar Laser Ranging fit, ELPMPP02DE405 which uses the ELPMPP02 DE405 fit and ELPMPP02DE406 which uses the ELPMPP02 DE406 fit.</param>
+        /// <returns>List of AASMoonPhasesDetails2 instances with the details.</returns>
+        /// <exception cref="Exception"></exception>
         public static List<AASMoonPhasesDetails2> Calculate(double StartJD, double EndJD, double StepInterval = 0.007,
             Algorithm algorithm = Algorithm.MeeusTruncated)
         {

--- a/Src/AASharp/AASMoonPhasesDetails2.cs
+++ b/Src/AASharp/AASMoonPhasesDetails2.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Instances of this class are returned by AASMoonPhases2.Calculate method.
+    /// </summary>
     public class AASMoonPhasesDetails2
     {
         public enum Type
@@ -17,7 +20,7 @@ namespace AASharp
         public Type type { get; set; } = Type.NotDefined;
 
         /// <summary>
-        ///  //When the event occurred in TT
+        /// When the event occurred in TT
         /// </summary>
         public double JD { get; set; }
     }

--- a/Src/AASharp/AASMoslemCalendar.cs
+++ b/Src/AASharp/AASMoslemCalendar.cs
@@ -1,7 +1,14 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides the algorithms which convert between the Julian and Moslem calendars. This refers to Chapter 9 in the book.
+    /// </summary>
     public static class AASMoslemCalendar
     {
+        /// <param name="Year">The year in the Moslem Calendar to convert</param>
+        /// <param name="Month">The month of the year in the Moslem Calendar (1 for Muharram to 12 for Dhu l-Hijja).</param>
+        /// <param name="Day">The day of the month in the Moslem Calendar.</param>
+        /// <returns>An instance of AASCalendarDate class with Julian year/month/day details.</returns>
         public static AASCalendarDate MoslemToJulian(long Year, long Month, long Day)
         {
             //What will be the return value
@@ -42,7 +49,11 @@
 
             return julianDate;
         }
-    
+
+        /// <param name="Year">The year in the Julian Calendar to convert. (Years are counted astronomically i.e. 1 BC = Year 0)</param>
+        /// <param name="Month">The month of the year in the Julian Calendar (1 for January to 12 for December).</param>
+        /// <param name="Day">The day of the month in the Julian Calendar.</param>
+        /// <returns>An instance of AASCalendarDate class with the Moslem year/month/day details.</returns>
         public static AASCalendarDate JulianToMoslem(long Year, long Month, long Day)
         {
             //What will be the return value
@@ -103,6 +114,8 @@
             return MoslemDate;
         }
 
+        /// <param name="Year">The year in the Moslem calendar.</param>
+        /// <returns>true if the specified year is leap otherwise false.</returns>
         public static bool IsLeap(long Year)
         {
           long R = Year % 30;

--- a/Src/AASharp/AASNearParabolic.cs
+++ b/Src/AASharp/AASNearParabolic.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the position of an object in an orbit which can be best modelled as near parabolic i.e. eccentricity between 0.98 and 1.02. Chapter 35 in the book includes support for calculating Near-parabolic orbits, but the code is provided in BASIC and the algorithm as presented has problems converging when the eccentricity is close to 1. Instead the algorithms used in this class are based upon the worked examples which Paul Schlyter has provided at http://stjarnhimlen.se/comp/tutorial.html#16
+    /// </summary>
     public static class AASNearParabolic
     {
         private static double Cbrt(double x)
@@ -29,6 +32,10 @@ namespace AASharp
             r = elements.q * (1 + w2) / (1 + w2 * f);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="elements">A class containing orbital elements</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASNearParabolicObjectDetails class with the details.</returns>
         public static AASNearParabolicObjectDetails Calculate(double JD, ref AASNearParabolicObjectElements elements, bool bHighPrecision)
         {
             double Epsilon = AASNutation.MeanObliquityOfEcliptic(elements.JDEquinox);

--- a/Src/AASharp/AASNearParabolicObjectDetails.cs
+++ b/Src/AASharp/AASNearParabolicObjectDetails.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASNearParabolic.Calculate method.
+    /// </summary>
     public class AASNearParabolicObjectDetails
     {
         public AASNearParabolicObjectDetails()
@@ -8,19 +11,61 @@
             HeliocentricRectangularEcliptical = new AAS3DCoordinate();
         }
 
+        /// <summary>
+        /// 3D rectangular heliocentric equatorial coordinates of the object.
+        /// </summary>
         public AAS3DCoordinate HeliocentricRectangularEquatorial { get; set; }
+        /// <summary>
+        /// 3D rectangular heliocentric ecliptical coordinates of the object.
+        /// </summary>
         public AAS3DCoordinate HeliocentricRectangularEcliptical { get; set; }
+        /// <summary>
+        /// The heliocentric ecliptical longitude in degrees of the object.
+        /// </summary>
         public double HeliocentricEclipticLongitude { get; set; }
+        /// <summary>
+        /// The heliocentric ecliptical latitude in degrees of the object.
+        /// </summary>
         public double HeliocentricEclipticLatitude { get; set; }
+        /// <summary>
+        /// The geocentric right ascension of the object as an hour angle (i.e. without light time correction applied).
+        /// </summary>
         public double TrueGeocentricRA { get; set; }
+        /// <summary>
+        /// The geocentric declination of the object in degrees (i.e. without light time correction applied).
+        /// </summary>
         public double TrueGeocentricDeclination { get; set; }
+        /// <summary>
+        /// The true distance in astronomical units between the Earth and the object.
+        /// </summary>
         public double TrueGeocentricDistance { get; set; }
+        /// <summary>
+        /// The light travel time in days from the Earth to the object.
+        /// </summary>
         public double TrueGeocentricLightTime { get; set; }
+        /// <summary>
+        /// The geocentric right ascension of the object as an hour angle (i.e. with light time correction applied)
+        /// </summary>
         public double AstrometricGeocentricRA { get; set; }
+        /// <summary>
+        /// The geocentric declination of the object in degrees (i.e. with light time correction applied)
+        /// </summary>
         public double AstrometricGeocentricDeclination { get; set; }
+        /// <summary>
+        /// The observed distance of the object in astronomical units.
+        /// </summary>
         public double AstrometricGeocentricDistance { get; set; }
+        /// <summary>
+        /// The observed light travel time of the object in days.
+        /// </summary>
         public double AstrometricGeocentricLightTime { get; set; }
+        /// <summary>
+        /// The elongation of the object to the Sun in degrees.
+        /// </summary>
         public double Elongation { get; set; }
+        /// <summary>
+        /// The phase angle (the angle Sun - object - Earth) in degrees.
+        /// </summary>
         public double PhaseAngle { get; set; }
     }
 }

--- a/Src/AASharp/AASNearParabolicObjectElements.cs
+++ b/Src/AASharp/AASNearParabolicObjectElements.cs
@@ -1,13 +1,37 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class as a parameter is required by the AASNearParabolic.Calculate method. 
+    /// </summary>
     public class AASNearParabolicObjectElements
     {
+        /// <summary>
+        /// The perihelion distance in astronomical units.
+        /// </summary>
         public double q { get; set; }
+        /// <summary>
+        /// The inclination of the plane of the orbit in degrees.
+        /// </summary>
         public double i { get; set; }
+        /// <summary>
+        /// The argument of the perihelion in degrees.
+        /// </summary>
         public double w { get; set; }
+        /// <summary>
+        /// The longitude of the ascending node in degrees.
+        /// </summary>
         public double omega { get; set; }
+        /// <summary>
+        /// The Julian Date for which equatorial coordinates should be calculated for.
+        /// </summary>
         public double JDEquinox { get; set; }
+        /// <summary>
+        /// The Julian date of the time of passage in perihelion.
+        /// </summary>
         public double T { get; set; }
+        /// <summary>
+        /// Eccentricity of the orbit
+        /// </summary>
         public double e { get; set; }
     }
 }

--- a/Src/AASharp/AASNeptune.cs
+++ b/Src/AASharp/AASNeptune.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Neptune. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASNeptune
     {
         #region coefficients
@@ -223,9 +226,12 @@ namespace AASharp
         { 
             new VSOP87Coefficient( 166,  4.552,  38.133 )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -277,6 +283,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -327,6 +336,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASNodeObjectDetails.cs
+++ b/Src/AASharp/AASNodeObjectDetails.cs
@@ -1,8 +1,17 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASNodes.PassageThroXXXNode methods.
+    /// </summary>
     public class AASNodeObjectDetails
     {
+        /// <summary>
+        /// The date in Dynamical time to when the body moves thro the ascending node.
+        /// </summary>
         public double t { get; set; }
+        /// <summary>
+        /// The radius vector in astronomical units.
+        /// </summary>
         public double radius { get; set; }
     }
 }

--- a/Src/AASharp/AASNodes.cs
+++ b/Src/AASharp/AASNodes.cs
@@ -2,8 +2,13 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the time of passages from the orbital elements of a planet or comet through the nodes of its orbit. This refers to Chapter 39 in the book.
+    /// </summary>
     public static class AASNodes
     {
+        /// <param name="elements">An instance of the AASEllipticalObjectElements class containing the orbital elements.</param>
+        /// <returns>An instance of AASNodeObjectDetails class with the details.</returns>
         public static AASNodeObjectDetails PassageThroAscendingNode(ref AASEllipticalObjectElements elements)
         {
             double v = AASCoordinateTransformation.MapTo0To360Range(-elements.w);
@@ -20,6 +25,8 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="elements">An instance of the AASEllipticalObjectElements class containing the orbital elements.</param>
+        /// <returns>An instance of AASNodeObjectDetails class with the details.</returns>
         public static AASNodeObjectDetails PassageThroDescendingNode(ref AASEllipticalObjectElements elements)
         {
             double v = AASCoordinateTransformation.MapTo0To360Range(180 - elements.w);
@@ -36,6 +43,8 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="elements">An instance of the AASParabolicObjectElements class containing the orbital elements.</param>
+        /// <returns>An instance of AASNodeObjectDetails class with the details.</returns>
         public static AASNodeObjectDetails PassageThroAscendingNode(ref AASParabolicObjectElements elements)
         {
             double v = AASCoordinateTransformation.MapTo0To360Range(-elements.w);
@@ -50,6 +59,8 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="elements">An instance of the AASParabolicObjectElements class containing the orbital elements.</param>
+        /// <returns>An instance of AASNodeObjectDetails class with the details.</returns>
         public static AASNodeObjectDetails PassageThroDescendingNode(ref AASParabolicObjectElements elements)
         {
             double v = AASCoordinateTransformation.MapTo0To360Range(180 - elements.w);

--- a/Src/AASharp/AASNutation.cs
+++ b/Src/AASharp/AASNutation.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of Nutation and the Obliquity of the Ecliptic. This refers to Chapter 22 and parts of Chapter 23 in the book.
+    /// </summary>
     public static class AASNutation
     {
         internal static readonly NutationCoefficient[] g_NutationCoefficients =
@@ -71,6 +74,8 @@ namespace AASharp
             new NutationCoefficient(  2, -1,  0,  2,  2,     -3,        0,      0,       0    )
         };
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The nutation in ecliptic longitude in arc seconds of a degree.</returns>
         public static double NutationInLongitude(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -106,6 +111,8 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The nutation in obliquity in arc seconds of a degree.</returns>
         public static double NutationInObliquity(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -141,6 +148,8 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The mean obliquity of the ecliptic in degrees.</returns>
         public static double MeanObliquityOfEcliptic(double JD)
         {
             double U = (JD - 2451545) / 3652500;
@@ -167,11 +176,22 @@ namespace AASharp
             + AASCoordinateTransformation.DMSToDegrees(0, 0, 2.45) * U10;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The true obliquity of the ecliptic in degrees.</returns>
         public static double TrueObliquityOfEcliptic(double JD)
         {
             return MeanObliquityOfEcliptic(JD) + AASCoordinateTransformation.DMSToDegrees(0, 0, NutationInObliquity(JD));
         }
 
+        /// <summary>
+        /// This refers to algorithm 23.1 on page 151.
+        /// </summary>
+        /// <param name="Alpha">The right ascension of the position in hour angles.</param>
+        /// <param name="Delta">The declination of the position in degrees.</param>
+        /// <param name="Obliquity">The obliquity of the Ecliptic in degrees.</param>
+        /// <param name="NutationInLongitude">The nutation in longitude in arc seconds of a degree.</param>
+        /// <param name="NutationInObliquity">The nutation in obliquity in arc seconds of a degree.</param>
+        /// <returns>The nutation in right ascension in arc seconds of a degree.</returns>
         public static double NutationInRightAscension(double Alpha, double Delta, double Obliquity, double NutationInLongitude, double NutationInObliquity)
         {
             //Convert to radians
@@ -182,6 +202,14 @@ namespace AASharp
             return (Math.Cos(Obliquity) + Math.Sin(Obliquity) * Math.Sin(Alpha) * Math.Tan(Delta)) * NutationInLongitude - Math.Cos(Alpha) * Math.Tan(Delta) * NutationInObliquity;
         }
 
+        /// <summary>
+        /// This refers to algorithm 23.1 on page 151.
+        /// </summary>
+        /// <param name="Alpha">The right ascension of the position in hour angles.</param>
+        /// <param name="Obliquity">The obliquity of the Ecliptic in degrees.</param>
+        /// <param name="NutationInLongitude">The nutation in longitude in arc seconds of a degree.</param>
+        /// <param name="NutationInObliquity">The nutation in obliquity in arc seconds of a degree.</param>
+        /// <returns>The nutation in declination in arc seconds of a degree.</returns>
         public static double NutationInDeclination(double Alpha, double Obliquity, double NutationInLongitude, double NutationInObliquity)
         {
             //Convert to radians

--- a/Src/AASharp/AASParabolic.cs
+++ b/Src/AASharp/AASParabolic.cs
@@ -2,8 +2,13 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the position of an object in a parabolic orbit. This refers to Chapter 34 in the book.
+    /// </summary>
     public static class AASParabolic
     {
+        /// <param name="W">The value W as described in algorithm 34.1 on page 241.</param>
+        /// <returns>The solution to Barkers equation as described in algorithm 34.3 on page 241.</returns>
         public static double CalculateBarkers(double W)
         {
             double S = W / 3;
@@ -21,6 +26,10 @@ namespace AASharp
             return S;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="elements">An instance of the AASParabolicObjectElements class with the orbit elements.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASParabolicObjectDetails class with the details.</returns>
         public static AASParabolicObjectDetails Calculate(double JD, ref AASParabolicObjectElements elements, bool bHighPrecision)
         {
             double Epsilon = AASNutation.MeanObliquityOfEcliptic(elements.JDEquinox);

--- a/Src/AASharp/AASParabolicObjectDetails.cs
+++ b/Src/AASharp/AASParabolicObjectDetails.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASParabolic.Calculate method.
+    /// </summary>
     public class AASParabolicObjectDetails
     {
         public AASParabolicObjectDetails()
@@ -8,19 +11,61 @@
             HeliocentricRectangularEcliptical = new AAS3DCoordinate();
         }
 
+        /// <summary>
+        /// 3D rectangular heliocentric equatorial coordinates of the object.
+        /// </summary>
         public AAS3DCoordinate HeliocentricRectangularEquatorial { get; set; }
+        /// <summary>
+        /// 3D rectangular heliocentric ecliptical coordinates of the object.
+        /// </summary>
         public AAS3DCoordinate HeliocentricRectangularEcliptical { get; set; }
+        /// <summary>
+        /// The heliocentric ecliptical longitude in degrees of the object.
+        /// </summary>
         public double HeliocentricEclipticLongitude { get; set; }
+        /// <summary>
+        /// The heliocentric ecliptical latitude in degrees of the object.
+        /// </summary>
         public double HeliocentricEclipticLatitude { get; set; }
+        /// <summary>
+        /// The geocentric right ascension of the object as an hour angle (i.e. without light time correction applied).
+        /// </summary>
         public double TrueGeocentricRA { get; set; }
+        /// <summary>
+        /// The geocentric declination of the object in degrees (i.e. without light time correction applied).
+        /// </summary>
         public double TrueGeocentricDeclination { get; set; }
+        /// <summary>
+        /// The true distance in astronomical units between the Earth and the object.
+        /// </summary>
         public double TrueGeocentricDistance { get; set; }
+        /// <summary>
+        /// The light travel time in days from the Earth to the object.
+        /// </summary>
         public double TrueGeocentricLightTime { get; set; }
+        /// <summary>
+        /// The geocentric right ascension of the object as an hour angle (i.e. with light time correction applied)
+        /// </summary>
         public double AstrometricGeocenticRA { get; set; }
+        /// <summary>
+        /// The geocentric declination of the object in degrees (i.e. with light time correction applied)
+        /// </summary>
         public double AstrometricGeocentricDeclination { get; set; }
+        /// <summary>
+        /// The observed distance of the object in astronomical units.
+        /// </summary>
         public double AstrometricGeocentricDistance { get; set; }
+        /// <summary>
+        /// The observed light travel time of the object in days.
+        /// </summary>
         public double AstrometricGeocentricLightTime { get; set; }
+        /// <summary>
+        /// The elongation of the object to the Sun in degrees.
+        /// </summary>
         public double Elongation { get; set; }
+        /// <summary>
+        /// The phase angle (the angle Sun - object - Earth) in degrees.
+        /// </summary>
         public double PhaseAngle { get; set; }
     }
 }

--- a/Src/AASharp/AASParabolicObjectElements.cs
+++ b/Src/AASharp/AASParabolicObjectElements.cs
@@ -1,12 +1,33 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is required as a parameter for the AASParabolic.Calculate method.
+    /// </summary>
     public class AASParabolicObjectElements
     {
+        /// <summary>
+        /// The perihelion distance in astronomical units.
+        /// </summary>
         public double q { get; set; }
+        /// <summary>
+        /// The inclination of the plane of the orbit in degrees.
+        /// </summary>
         public double i { get; set; }
+        /// <summary>
+        /// The argument of the perihelion in degrees.
+        /// </summary>
         public double w { get; set; }
+        /// <summary>
+        /// The longitude of the ascending node in degrees.
+        /// </summary>
         public double omega { get; set; }
+        /// <summary>
+        /// The Julian Date for which equatorial coordinates should be calculated for.
+        /// </summary>
         public double JDEquinox { get; set; }
+        /// <summary>
+        /// The Julian date of the time of passage in perihelion.
+        /// </summary>
         public double T { get; set; }
     }
 }

--- a/Src/AASharp/AASParallactic.cs
+++ b/Src/AASharp/AASParallactic.cs
@@ -2,8 +2,18 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for measurement of various angles on the celestial globe. This refers to Chapter 14 in the book.
+    /// </summary>
     public static class AASParallactic
     {
+        /// <summary>
+        /// This refers to algorithm 14.1 on page 98.
+        /// </summary>
+        /// <param name="HourAngle">The hour angle.</param>
+        /// <param name="Latitude">The latitude of the position in degrees.</param>
+        /// <param name="delta">The declination in degrees.</param>
+        /// <returns>Returns the parallactic angle (the ZCN angle) and is generally designated by q.</returns>
         public static double ParallacticAngle(double HourAngle, double Latitude, double delta)
         {
             HourAngle = AASCoordinateTransformation.HoursToRadians(HourAngle);
@@ -13,6 +23,13 @@ namespace AASharp
             return AASCoordinateTransformation.RadiansToDegrees(Math.Atan2(Math.Sin(HourAngle), Math.Tan(Latitude) * Math.Cos(delta) - Math.Sin(delta) * Math.Cos(HourAngle)));
         }
 
+        /// <summary>
+        /// This refers to algorithm 14.2 on page 99.
+        /// </summary>
+        /// <param name="LocalSiderealTime">The local sidereal time measured in hours.</param>
+        /// <param name="ObliquityOfEcliptic">The obliquity of the ecliptic in degrees.</param>
+        /// <param name="Latitude">The latitude of the position in degrees.</param>
+        /// <returns>Returns the ecliptic longitude of two points which are (180 degrees apart) on the horizon.</returns>
         public static double EclipticLongitudeOnHorizon(double LocalSiderealTime, double ObliquityOfEcliptic, double Latitude)
         {
             LocalSiderealTime = AASCoordinateTransformation.HoursToRadians(LocalSiderealTime);
@@ -23,6 +40,13 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(value);
         }
 
+        /// <summary>
+        /// This refers to algorithm at the top of page 100.
+        /// </summary>
+        /// <param name="LocalSiderealTime">The local sidereal time measured in hours.</param>
+        /// <param name="ObliquityOfEcliptic">The obliquity of the ecliptic in degrees.</param>
+        /// <param name="Latitude">The latitude of the position in degrees.</param>
+        /// <returns>Returns the angle in degrees of the diurnal path of a celestial body (not the ecliptic) relative to the horizon at the time of its rising or setting.</returns>
         public static double AngleBetweenEclipticAndHorizon(double LocalSiderealTime, double ObliquityOfEcliptic, double Latitude)
         {
             LocalSiderealTime = AASCoordinateTransformation.HoursToRadians(LocalSiderealTime);
@@ -33,6 +57,13 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To360Range(value);
         }
 
+        /// <summary>
+        /// This refers to algorithm at the top of page 100.
+        /// </summary>
+        /// <param name="Lambda">The ecliptical longitude in degrees.</param>
+        /// <param name="Beta">The ecliptical latitude of the star in degrees.</param>
+        /// <param name="ObliquityOfEcliptic">The obliquity of the ecliptic in degrees.</param>
+        /// <returns>Return the angle in degrees between the direction of the northern celestial pole and the direction of the north pole of the ecliptic, at the star.</returns>
         public static double AngleBetweenNorthCelestialPoleAndNorthPoleOfEcliptic(double Lambda, double Beta, double ObliquityOfEcliptic)
         {
             Lambda = AASCoordinateTransformation.DegreesToRadians(Lambda);

--- a/Src/AASharp/AASParallax.cs
+++ b/Src/AASharp/AASParallax.cs
@@ -2,21 +2,39 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the topocentric coordinates of a body as seen from the observer's place on the Earth's surface. This refers to Chapter 40 in the book.
+    /// </summary>
     public static class AASParallax
     {
         private readonly static double g_AAParallax_C1 = Math.Sin(AASCoordinateTransformation.DegreesToRadians(AASCoordinateTransformation.DMSToDegrees(0, 0, 8.794)));
 
+        /// <param name="Distance">The distance (in astronomical units) to the body.</param>
+        /// <returns>Returns the parallax in degrees.</returns>
         public static double DistanceToParallax(double Distance)
         {
             double pi = Math.Asin(g_AAParallax_C1 / Distance);
             return AASCoordinateTransformation.RadiansToDegrees(pi);
         }
 
+        /// <param name="Parallax">The parallax of the body in degrees.</param>
+        /// <returns>Returns the distance in astronomical units.</returns>
         public static double ParallaxToDistance(double Parallax)
         {
             return g_AAParallax_C1 / Math.Sin(AASCoordinateTransformation.DegreesToRadians(Parallax));
         }
 
+        /// <summary>
+        /// This returns the difference between the geocentric and topocentric values. This refers to equation 40.4 and 40.5 on page 280.
+        /// </summary>
+        /// <param name="Alpha">The right ascension in hours of the object at time JD.</param>
+        /// <param name="Delta">The declination in degrees of the object at time JD.</param>
+        /// <param name="Distance">The distance (in astronomical units) to the Earth.</param>
+        /// <param name="Longitude">The longitude in degrees (Positive west, negative east from Greenwich).</param>
+        /// <param name="Latitude">The latitude in degrees.</param>
+        /// <param name="Height">The observer's height above sea level in meters.</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>Returns the corrections in equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the correction in right ascension expressed as an hour angle and the y value corresponds to the correction in declination in degrees.</returns>
         public static AAS2DCoordinate Equatorial2TopocentricDelta(double Alpha, double Delta, double Distance, double Longitude, double Latitude, double Height, double JD)
         {
             double RhoSinThetaPrime = AASGlobe.RhoSinThetaPrime(Latitude, Height);
@@ -41,6 +59,17 @@ namespace AASharp
             return DeltaTopocentric;
         }
 
+        /// <summary>
+        /// This returns the rigorous conversion between the geocentric and topocentric values. This refers to equation 40.2 and 40.3 on page 279.
+        /// </summary>
+        /// <param name="Alpha">The right ascension in hours of the object at time JD.</param>
+        /// <param name="Delta">The declination in degrees of the object at time JD.</param>
+        /// <param name="Distance">The distance (in astronomical units) to the Earth.</param>
+        /// <param name="Longitude">The longitude in degrees.</param>
+        /// <param name="Latitude">The latitude in degrees.</param>
+        /// <param name="Height">The observer's height above sea level in meters</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to right ascension expressed as an hour angle and the y value corresponds to the right ascension in degrees.</returns>
         public static AAS2DCoordinate Equatorial2Topocentric(double Alpha, double Delta, double Distance, double Longitude, double Latitude, double Height, double JD)
         {
             double RhoSinThetaPrime = AASGlobe.RhoSinThetaPrime(Latitude, Height);
@@ -70,6 +99,15 @@ namespace AASharp
             return Topocentric;
         }
 
+        /// <param name="Lambda">The ecliptical longitude in degrees.</param>
+        /// <param name="Beta">The ecliptical latitude in degrees.</param>
+        /// <param name="Semidiameter">The geocentric semi diameter in degrees.</param>
+        /// <param name="Distance">The distance (in astronomical units) to the Earth.</param>
+        /// <param name="Epsilon">The obliquity of the ecliptic in degrees.</param>
+        /// <param name="Latitude">The latitude in degrees.</param>
+        /// <param name="Height">The observer's height above sea level in meters.</param>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>An instance of AASTopocentricEclipticDetails class with the details.</returns>
         public static AASTopocentricEclipticDetails Ecliptic2Topocentric(double Lambda, double Beta, double Semidiameter, double Distance, double Epsilon, double Latitude, double Height, double JD)
         {
             double S = AASGlobe.RhoSinThetaPrime(Latitude, Height);

--- a/Src/AASharp/AASPhysicalJupiter.cs
+++ b/Src/AASharp/AASPhysicalJupiter.cs
@@ -2,8 +2,14 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of various physical parameters related to the Jupiter. This refers to Chapter 43 in the book.
+    /// </summary>
     public static class AASPhysicalJupiter
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASPhysicalJupiterDetails class with the details.</returns>
         public static AASPhysicalJupiterDetails Calculate(double JD, bool bHighPrecision)
         {
             //What will be the return value

--- a/Src/AASharp/AASPhysicalJupiterDetails.cs
+++ b/Src/AASharp/AASPhysicalJupiterDetails.cs
@@ -1,13 +1,37 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASPhysicalJupiter.Calculate method.
+    /// </summary>
     public class AASPhysicalJupiterDetails
     {
+        /// <summary>
+        /// The planetocentric declination in degrees of the Earth.
+        /// </summary>
         public double DE { get; set; }
+        /// <summary>
+        /// The planetocentric declination in degrees of the Sun.
+        /// </summary>
         public double DS { get; set; }
+        /// <summary>
+        /// The geometric longitude in degrees of the central meridian for System 1.
+        /// </summary>
         public double Geometricw1 { get; set; }
+        /// <summary>
+        /// The geometric longitude in degrees of the central meridian for System 2.
+        /// </summary>
         public double Geometricw2 { get; set; }
+        /// <summary>
+        /// The apparent longitude in degrees of the central meridian for System 1.
+        /// </summary>
         public double Apparentw1 { get; set; }
+        /// <summary>
+        /// The geometric longitude in degrees of the central meridian for System 2.
+        /// </summary>
         public double Apparentw2 { get; set; }
+        /// <summary>
+        /// The position angle of Jupiter's northern rotational pole in degrees.
+        /// </summary>
         public double P { get; set; }
     }
 }

--- a/Src/AASharp/AASPhysicalMars.cs
+++ b/Src/AASharp/AASPhysicalMars.cs
@@ -2,11 +2,14 @@ using System;
 
 namespace AASharp
 {
-    //Member variables
-
-
+    /// <summary>
+    /// This class provides for calculation of various physical parameters related to the Mars. This refers to Chapter 42 in the book.
+    /// </summary>
     public static class AASPhysicalMars
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASPhysicalMarsDetails class with the details.</returns>
         public static AASPhysicalMarsDetails Calculate(double JD, bool bHighPrecision)
         {
             //What will be the return value

--- a/Src/AASharp/AASPhysicalMarsDetails.cs
+++ b/Src/AASharp/AASPhysicalMarsDetails.cs
@@ -1,14 +1,41 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASPhysicalMars.Calculate method.
+    /// </summary>
     public class AASPhysicalMarsDetails
     {
+        /// <summary>
+        /// The planetocentric declination in degrees of the Earth.
+        /// </summary>
         public double DE { get; set; }
+        /// <summary>
+        /// The planetocentric declination in degrees of the Sun.
+        /// </summary>
         public double DS { get; set; }
+        /// <summary>
+        /// The aerographic longitude in degrees of the central meridian as seen from Earth.
+        /// </summary>
         public double w { get; set; }
+        /// <summary>
+        /// The geocentric position angle of Mars' northern rotational pole in degrees.
+        /// </summary>
         public double P { get; set; }
+        /// <summary>
+        /// The position angle in degrees of the mid-point of the illuminated limb.
+        /// </summary>
         public double X { get; set; }
+        /// <summary>
+        /// The illuminated fraction of the planet's disk.
+        /// </summary>
         public double k { get; set; }
+        /// <summary>
+        /// The defect of illumination.
+        /// </summary>
         public double q { get; set; }
+        /// <summary>
+        /// The apparent diameter of Mars in arc seconds.
+        /// </summary>
         public double d { get; set; }
     }
 }

--- a/Src/AASharp/AASPhysicalMoon.cs
+++ b/Src/AASharp/AASPhysicalMoon.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of various physical parameters related to the Moon. This refers to Chapter 53 in the book.
+    /// </summary>
     public static class AASPhysicalMoon
     {
         public static void CalculateOpticalLibration(double JD, double Lambda, double Beta, ref double ldash, ref double bdash, ref double ldash2, ref double bdash2, ref double epsilon, ref double omega, ref double DeltaU, ref double sigma, ref double I, ref double rho)
@@ -138,6 +141,11 @@ namespace AASharp
             return details;
         }
 
+        /// <summary>
+        /// Calculates the physical parameters referred to the centre of the Earth
+        /// </summary>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>An instance of AASPhysicalMoonDetails class with the details.</returns>
         public static AASPhysicalMoonDetails CalculateGeocentric(double JD)
         {
             double Lambda = 0;
@@ -147,6 +155,13 @@ namespace AASharp
             return CalculateHelper(JD, ref Lambda, ref Beta, ref epsilon, ref Equatorial);
         }
 
+        /// <summary>
+        /// Calculates the physical parameters referred to the specified position on the Earth
+        /// </summary>
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="Longitude">The topocentric longitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="Latitude">The topocentric latitude in degrees of the position to perform the calculation for.</param>
+        /// <returns>An instance of AASPhysicalMoonDetails class with the details.</returns>
         public static AASPhysicalMoonDetails CalculateTopocentric(double JD, double Longitude, double Latitude)
         {
             //First convert to radians
@@ -183,6 +198,9 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASSelenographicMoonDetails class with the details.</returns>
         public static AASSelenographicMoonDetails CalculateSelenographicPositionOfSun(double JD, bool bHighPrecision)
         {
             double R = AASEarth.RadiusVector(JD, bHighPrecision) * 149597970;
@@ -216,6 +234,11 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="Longitude">The selenographic longitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="Latitude">The selenographic latitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>Returns the altitude in degrees of the Sun at the specified lunar location.</returns>
         public static double AltitudeOfSun(double JD, double Longitude, double Latitude, bool bHighPrecision)
         {
             //Calculate the selenographic details
@@ -249,11 +272,21 @@ namespace AASharp
             return JDResult;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="Longitude">The selenographic longitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="Latitude">The selenographic latitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>Returns the nearest Julian date in Dynamical time when the Sun rises at the specified lunar location. This value will always be earlier than the parameter "JD"</returns>
         public static double TimeOfSunrise(double JD, double Longitude, double Latitude, bool bHighPrecision)
         {
             return SunriseSunsetHelper(JD, Longitude, Latitude, true, bHighPrecision);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="Longitude">The selenographic longitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="Latitude">The selenographic latitude in degrees of the position to perform the calculation for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>Returns the nearest Julian date in Dynamical time when the Sun sets at the specified lunar location. This value will always be later than the parameter "JD"</returns>
         public static double TimeOfSunset(double JD, double Longitude, double Latitude, bool bHighPrecision)
         {
             return SunriseSunsetHelper(JD, Longitude, Latitude, false, bHighPrecision);

--- a/Src/AASharp/AASPhysicalMoonDetails.cs
+++ b/Src/AASharp/AASPhysicalMoonDetails.cs
@@ -1,13 +1,37 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASPhysicalMoon.CalculateGeocentric and AASPhysicalMoon.CalculateTopocentric methods.
+    /// </summary>
     public class AASPhysicalMoonDetails
     {
+        /// <summary>
+        /// The optical libration in longitude in degrees.
+        /// </summary>
         public double ldash { get; set; }
+        /// <summary>
+        /// The optical libration in latitude in degrees.
+        /// </summary>
         public double bdash { get; set; }
+        /// <summary>
+        /// The physical libration in longitude in degrees.
+        /// </summary>
         public double ldash2 { get; set; }
+        /// <summary>
+        /// The physical libration in latitude in degrees.
+        /// </summary>
         public double bdash2 { get; set; }
+        /// <summary>
+        /// The total libration in longitude in degrees.
+        /// </summary>
         public double l { get; set; }
+        /// <summary>
+        /// The total libration in latitude in degrees.
+        /// </summary>
         public double b { get; set; }
+        /// <summary>
+        /// The position angle in degrees of the Moon's axis of rotation.
+        /// </summary>
         public double P { get; set; }
     }
 }

--- a/Src/AASharp/AASPhysicalSun.cs
+++ b/Src/AASharp/AASPhysicalSun.cs
@@ -2,8 +2,14 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of various physical parameters related to the Sun. This refers to Chapter 29 in the book.
+    /// </summary>
     public static class AASPhysicalSun
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASPhysicalSunDetails class with the details.</returns>
         public static AASPhysicalSunDetails Calculate(double JD, bool bHighPrecision)
         {
             double theta = AASCoordinateTransformation.MapTo0To360Range((JD - 2398220) * 360 / 25.38);

--- a/Src/AASharp/AASPhysicalSunDetails.cs
+++ b/Src/AASharp/AASPhysicalSunDetails.cs
@@ -1,9 +1,21 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASPhysicalSun.Calculate method.
+    /// </summary>
     public class AASPhysicalSunDetails
     {
+        /// <summary>
+        /// The position angle in degrees of the northern extremity of the axis of rotation.
+        /// </summary>
         public double P { get; set; }
+        /// <summary>
+        /// The heliographic latitude in degrees of the centre of the solar disk.
+        /// </summary>
         public double B0 { get; set; }
+        /// <summary>
+        /// The heliographic longitude in degrees of the centre of the solar disk.
+        /// </summary>
         public double L0 { get; set; }
     }
 }

--- a/Src/AASharp/AASPlanetPerihelionAphelion.cs
+++ b/Src/AASharp/AASPlanetPerihelionAphelion.cs
@@ -2,29 +2,48 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for the calculation of the time when a planet is in perihelion or in aphelion. This refers to Chapter 38 in the book.
+    /// </summary>
     public static class AASPlanetPerihelionAphelion
     {
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Mercury for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long MercuryK(double Year)
         {
             return (long)(4.15201 * (Year - 2000.12));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double MercuryPerihelion(long k)
         {
             return 2451590.257 + 87.96934963 * k;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double MercuryAphelion(long k)
         {
             double kdash = k + 0.5;
             return 2451590.257 + 87.96934963 * kdash;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Venus for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long VenusK(double Year)
         {
             return (long)(1.62549 * (Year - 2000.53));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double VenusPerihelion(long k)
         {
             double kdash = k;
@@ -32,6 +51,8 @@ namespace AASharp
             return 2451738.233 + 224.7008188 * kdash - 0.0000000327 * ksquared;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double VenusAphelion(long k)
         {
             double kdash = k + 0.5;
@@ -39,11 +60,19 @@ namespace AASharp
             return 2451738.233 + 224.7008188 * kdash - 0.0000000327 * ksquared;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.EarthPerihelion and AASPlanetPerihelionAphelion.EarthAphelion for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long EarthK(double Year)
         {
             return (long)(0.99997 * (Year - 2000.01));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="bBarycentric">If true, the calculation is for the barycenter of the Earth - Moon system, false implies the Earth itself.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double EarthPerihelion(long k, bool bBarycentric)
         {
             double kdash = k;
@@ -74,6 +103,9 @@ namespace AASharp
             return JD;
         }
 
+        /// <param name="k">The K value to calculate the Aphelion for. This K value must be an integer value + 0.5. Any other value of K will give meaningless values.</param>
+        /// <param name="bBarycentric">If true, the calculation is for the barycenter of the Earth - Moon system, false implies the Earth itself</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double EarthAphelion(long k, bool bBarycentric)
         {
             double kdash = k + 0.5;
@@ -104,11 +136,18 @@ namespace AASharp
             return JD;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Mars for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long MarsK(double Year)
         {
             return (long)(0.53166 * (Year - 2001.78));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double MarsPerihelion(long k)
         {
             double kdash = k;
@@ -116,6 +155,8 @@ namespace AASharp
             return 2452195.026 + 686.9957857 * kdash - 0.0000001187 * ksquared;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double MarsAphelion(long k)
         {
             double kdash = k + 0.5;
@@ -123,11 +164,18 @@ namespace AASharp
             return 2452195.026 + 686.9957857 * kdash - 0.0000001187 * ksquared;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Jupiter for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long JupiterK(double Year)
         {
             return (long)(0.08430 * (Year - 2011.20));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double JupiterPerihelion(long k)
         {
             double kdash = k;
@@ -135,6 +183,8 @@ namespace AASharp
             return 2455636.936 + 4332.897065 * kdash + 0.0001367 * ksquared;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double JupiterAphelion(long k)
         {
             double kdash = k + 0.5;
@@ -142,11 +192,18 @@ namespace AASharp
             return 2455636.936 + 4332.897065 * kdash + 0.0001367 * ksquared;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Saturn for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long SaturnK(double Year)
         {
             return (long)(0.03393 * (Year - 2003.52));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double SaturnPerihelion(long k)
         {
             double kdash = k;
@@ -154,6 +211,8 @@ namespace AASharp
             return 2452830.12 + 10764.21676 * kdash + 0.000827 * ksquared;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double SaturnAphelion(long k)
         {
             double kdash = k + 0.5;
@@ -161,11 +220,18 @@ namespace AASharp
             return 2452830.12 + 10764.21676 * kdash + 0.000827 * ksquared;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Uranus for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long UranusK(double Year)
         {
             return (long)(0.01190 * (Year - 2051.1));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double UranusPerihelion(long k)
         {
             double kdash = k;
@@ -173,6 +239,8 @@ namespace AASharp
             return 2470213.5 + 30694.8767 * kdash - 0.00541 * ksquared;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double UranusAphelion(long k)
         {
             double kdash = k + 0.5;
@@ -180,11 +248,18 @@ namespace AASharp
             return 2470213.5 + 30694.8767 * kdash - 0.00541 * ksquared;
         }
 
+        /// <summary>
+        /// Please note that the return value from this method must be rounded by client code before calling other methods in this class with this K value. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
+        /// </summary>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <returns>Returns the approximate value of K required by AASPlanetPerihelionAphelion.Neptune for calculation of the dates of Perihelion or Aphelion.</returns>
         public static long NeptuneK(double Year)
         {
             return (long)(0.00607 * (Year - 2047.5));
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Perihelion occurs.</returns>
         public static double NeptunePerihelion(long k)
         {
             double kdash = k;
@@ -192,6 +267,8 @@ namespace AASharp
             return 2468895.1 + 60190.33 * kdash + 0.03429 * ksquared;
         }
 
+        /// <param name="k">The K value to calculate the Perihelion or Aphelion for. This K value must be an integer value for Perihelion or an integer value + 0.5 for Aphelion. Any other value of K will give meaningless values.</param>
+        /// <returns>Returns the date in Dynamical time when the specified Aphelion occurs.</returns>
         public static double NeptuneAphelion(long k)
         {
             double kdash = k + 0.5;

--- a/Src/AASharp/AASPlanetaryPhenomena.cs
+++ b/Src/AASharp/AASPlanetaryPhenomena.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for the calculation of several configurations involving planets Mercury to Neptune; oppositions and conjunctions with the Sun, greatest elongations, and stations. This refers to Chapter 36 in the book.
+    /// </summary>
     public static class AASPlanetaryPhenomena
     {
         internal struct PlanetaryPhenomenaCoefficient1
@@ -38,12 +41,12 @@ namespace AASharp
         new PlanetaryPhenomenaCoefficient1( 2451569.379, 367.486703,  21.5569,  2.194998    ) };
 
         /// <summary>
-        ///
+        /// Please note that the return value from this method must be rounded to an integer by client code before calling other methods in this class with this K value. Any other value of K will give meaningless values. Prior to v2.26 of AA+, this method would return the K value already rounded. This change was made to make this method's behavior consistent with all the other methods in the AA+ framework which return so called "K" values.
         /// </summary>
-        /// <param name="Year"></param>
-        /// <param name="planetaryObject"></param>
-        /// <param name="eventType"></param>
-        /// <returns></returns>
+        /// <param name="Year">The Year including decimals to calculate the K value for.</param>
+        /// <param name="planetaryObject">An enum specifying the planet to calculate for.</param>
+        /// <param name="eventType">An enum to specify the event type to calculate.</param>
+        /// <returns>Returns the approximate value of K (required by the other methods of AASPlanetaryPhenomena) for calculation of the various event types.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when an incorrect EventType is specified for a given PlanetaryObject. When planetaryObject is one of the four inner planets, eventType must be either EventType.OPPOSITION or EventType.CONJUNCTION. When planetaryObject is not one of the four inner planets, eventType must be either EventType.INFERIOR_CONJUNCTION or EventType.SUPERIOR_CONJUNCTION.</exception>
         public static double K(double Year, PlanetaryObject planetaryObject, EventType eventType)
         {
@@ -78,14 +81,11 @@ namespace AASharp
             return Math.Floor(k + 0.5);
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="Year"></param>
-        /// <param name="planetaryObject"></param>
-        /// <param name="eventType"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when an incorrect EventType is specified for a given PlanetaryObject. When planetaryObject is not one of the three inner planets, eventType must be one of the following: OPPOSITION, CONJUNCTION, STATION1, STATION2. When planetaryObject is one of the three inner planets, eventType must be either EventType.INFERIOR_CONJUNCTION or EventType.SUPERIOR_CONJUNCTION.</exception>
+        /// <param name="k">The K value to calculate the phenomena for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="planetaryObject">An enum specifying the planet to calculate for.</param>
+        /// <param name="eventType">An enum to specify the event type to calculate.</param>
+        /// <returns>Returns the date in Dynamical time when the specified mean planetary configuration occurs (that is, calculated from circular orbits and uniform planetary motions).</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static double Mean(double k, PlanetaryObject planetaryObject, EventType eventType)
         {
             uint nCoefficient;
@@ -118,14 +118,11 @@ namespace AASharp
             return g_PlanetaryPhenomenaCoefficient1[nCoefficient].A + g_PlanetaryPhenomenaCoefficient1[nCoefficient].B * k;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="k"></param>
-        /// <param name="planetaryObject"></param>
-        /// <param name="eventType"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when an incorrect EventType is specified for a given PlanetaryObject. When planetaryObject is not one of the three inner planets, eventType must be one of the following: OPPOSITION, CONJUNCTION, STATION1, STATION2. When planetaryObject is one of the three inner planets, eventType must be one of the following: INFERIOR_CONJUNCTION, SUPERIOR_CONJUNCTION, EASTERN_ELONGATION, WESTERN_ELONGATION, STATION1, STATION2.</exception>
+        /// <param name="k">The K value to calculate the phenomena for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="planetaryObject">An enum specifying the planet to calculate for.</param>
+        /// <param name="eventType">An enum to specify the event type to calculate.</param>
+        /// <returns>Returns the date in Dynamical time when the true planetary configuration occurs.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static double True(double k, PlanetaryObject planetaryObject, EventType eventType)
         {
             double JDE0;
@@ -618,6 +615,11 @@ namespace AASharp
             return JDE0 + delta;
         }
 
+        /// <param name="k">The K value to calculate the phenomena for. This K value must be an integer value. Any other value of K will give meaningless values.</param>
+        /// <param name="planetaryObject">An enum specifying the planet to calculate for.</param>
+        /// <param name="bEastern">true if you want the elongation value for the eastern elongation, otherwise false implies western elongation.</param>
+        /// <returns>the value of the greatest elongation of a planet.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
         public static double ElongationValue(double k, PlanetaryObject planetaryObject, bool bEastern)
         {
             if (!(planetaryObject < PlanetaryObject.MARS))

--- a/Src/AASharp/AASPluto.cs
+++ b/Src/AASharp/AASPluto.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Pluto. This refers to Chapter 37 in the book.
+    /// </summary>
     public static class AASPluto
     {
         #region coefficients
@@ -193,9 +196,11 @@ namespace AASharp
             new PlutoCoefficient2(  19,         35       ),
             new PlutoCoefficient2(  10,         3        )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the standard equinox J2000.</returns>
         public static double EclipticLongitude(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -219,6 +224,8 @@ namespace AASharp
             return L;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the standard equinox J2000.</returns>
         public static double EclipticLatitude(double JD)
         {
             double T = (JD - 2451545) / 36525;
@@ -241,6 +248,8 @@ namespace AASharp
             return L;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD)
         {
             double T = (JD - 2451545) / 36525;

--- a/Src/AASharp/AASPrecession.cs
+++ b/Src/AASharp/AASPrecession.cs
@@ -2,8 +2,17 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for the calculation of the slow drift that the direction of the rotational axis of the Earth undergoes over time. This refers to Chapter 21 in the book.
+    /// </summary>
     public static class AASPrecession
     {
+        /// <param name="t">The number of years from the starting epoch, negative in the past and positive in the future.</param>
+        /// <param name="Alpha">The right ascension expressed as an hour angle.</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <param name="PMAlpha">The proper motion in right ascension in arc seconds per year.</param>
+        /// <param name="PMDelta">The proper motion in declination in arc seconds per year.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the right ascension expressed as an hour angle and the y value corresponds to the declination in degrees.</returns>
         public static AAS2DCoordinate AdjustPositionUsingUniformProperMotion(double t, double Alpha, double Delta, double PMAlpha, double PMDelta)
         {
             AAS2DCoordinate value = new AAS2DCoordinate {X = Alpha + (PMAlpha * t / 3600), Y = Delta + (PMDelta * t / 3600)};
@@ -11,6 +20,14 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="r">The stars distance in parsecs.</param>
+        /// <param name="DeltaR">The radial velocity  in km/s.</param>
+        /// <param name="t">The number of years from the starting epoch, negative in the past and positive in the future.</param>
+        /// <param name="Alpha">The right ascension expression as an hour angle.</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <param name="PMAlpha">The proper motion in right ascension in arc seconds per year.</param>
+        /// <param name="PMDelta">The proper motion in declination in arc seconds per year.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the right ascension expressed as an hour angle and the y value corresponds to the declination in degrees.</returns>
         public static AAS2DCoordinate AdjustPositionUsingMotionInSpace(double r, double DeltaR, double t, double Alpha, double Delta, double PMAlpha, double PMDelta)
         {
             //Convert DeltaR from km/s to Parsecs / Year
@@ -45,6 +62,11 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Alpha">The right ascension in hours of the object at time JD0.</param>
+        /// <param name="Delta">The declination in degrees of the object at time JD0.</param>
+        /// <param name="JD0">The date in Dynamical time corresponding to the initial epoch.</param>
+        /// <param name="JD">The date in Dynamical time corresponding to the final epoch.</param>
+        /// <returns>Returns the precessed equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the right ascension as an hour angle and the y value corresponds to the declination in degrees.</returns>
         public static AAS2DCoordinate PrecessEquatorial(double Alpha, double Delta, double JD0, double JD)
         {
             double T = (JD0 - 2451545.0) / 36525;
@@ -71,6 +93,11 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Alpha">The right ascension in hours of the object at time JD in the FK4 system.</param>
+        /// <param name="Delta">The declination in degrees of the object at time JD in the FK4 system.</param>
+        /// <param name="JD0">The date in Dynamical time corresponding to the initial epoch.</param>
+        /// <param name="JD">The date in Dynamical time corresponding to the final epoch.</param>
+        /// <returns>Returns the converted equatorial coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the equatorial right ascension in the FK5 system as an hour angle and the y value corresponds to the declination in the FK5 system in degrees.</returns>
         public static AAS2DCoordinate PrecessEquatorialFK4(double Alpha, double Delta, double JD0, double JD)
         {
             double T = (JD0 - 2415020.3135) / 36524.2199;
@@ -97,6 +124,11 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Lambda">The ecliptical longitude in degrees.</param>
+        /// <param name="Beta">The ecliptical latitude of the star in degrees.</param>
+        /// <param name="JD0">The date in Dynamical time corresponding to the initial epoch.</param>
+        /// <param name="JD">The date in Dynamical time corresponding to the final epoch.</param>
+        /// <returns>Returns the converted ecliptic coordinates in a AAS2DCoordinate class. The x value in the class corresponds to the ecliptical longitude in degrees and the y value corresponds to the ecliptical latitude in degrees.</returns>
         public static AAS2DCoordinate PrecessEcliptic(double Lambda, double Beta, double JD0, double JD)
         {
             double T = (JD0 - 2451545.0) / 36525;
@@ -123,6 +155,13 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Alpha">The right ascension expressed as an hour angle.</param>
+        /// <param name="Delta">The declination in degrees.</param>
+        /// <param name="Beta">The ecliptical latitude of the star in degrees.</param>
+        /// <param name="PMAlpha">The proper motion in right ascension in arc seconds per year.</param>
+        /// <param name="PMDelta">The proper motion of the declination in arc seconds per year.</param>
+        /// <param name="Epsilon">The obliquity of the ecliptic in degrees.</param>
+        /// <returns>Returns the converted ecliptic proper motions in a AAS2DCoordinate class. The x value in the class corresponds to the proper motion in ecliptical longitude in arc seconds per year and the y value corresponds to the proper motion in ecliptical latitude in arc seconds per year.</returns>
         public static AAS2DCoordinate EquatorialPMToEcliptic(double Alpha, double Delta, double Beta, double PMAlpha, double PMDelta, double Epsilon)
         {
             //Convert to radians

--- a/Src/AASharp/AASRefraction.cs
+++ b/Src/AASharp/AASRefraction.cs
@@ -2,8 +2,15 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for conversion between apparent and true altitude above the horizon. This refers to Chapter 16 in the book.
+    /// </summary>
     public static class AASRefraction
     {
+        /// <param name="Altitude">The apparent altitude in degrees.</param>
+        /// <param name="Pressure">The atmospheric pressure in millibars</param>
+        /// <param name="Temperature">The air temperature in degrees Celsius.</param>
+        /// <returns>the refraction in degrees.</returns>
         public static double RefractionFromApparent(double Altitude, double Pressure = 1010, double Temperature = 10)
         {
             //return a constant value from this method if the altitude is below a specific value
@@ -16,6 +23,10 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="Altitude">The true altitude in degrees.</param>
+        /// <param name="Pressure">The atmospheric pressure in millibars</param>
+        /// <param name="Temperature">The air temperature in degrees Celsius.</param>
+        /// <returns>the refraction in degrees.</returns>
         public static double RefractionFromTrue(double Altitude, double Pressure = 1010, double Temperature = 10)
         {
             //return a constant value from this method if the altitude is below a specific value

--- a/Src/AASharp/AASRiseSetObject.cs
+++ b/Src/AASharp/AASRiseSetObject.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// Used by AASRiseTransitSet2.Calculate method.
+    /// </summary>
     public enum AASRiseSetObject
     {
         SUN,

--- a/Src/AASharp/AASRiseTransitSet.cs
+++ b/Src/AASharp/AASRiseTransitSet.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the time of rise, transit and set of a celestial body. This refers to Chapter 15 in the book. Please note that this class is now considered deprecated as of v2.02 of AA+ and may be removed in a future release of the library. Please use the AASRiseTransitSet2 class instead.
+    /// </summary>
     [Obsolete("Use AASRiseTransitSet2")]
     public static class AASRiseTransitSet
     {
@@ -167,6 +170,23 @@ namespace AASharp
             }
         }
 
+        /// <summary>
+        /// Bear in mind that the times calculated for the phenomena are for the same UTC date. This means that when you are in a non GMT timezone, the calculated local times can be for the previous or next day. Please bear this issue in mind if you are generating an ephemeris of rise, transit and set times for a celestial object for a specific range of local dates. In this case, you will need to rerun the calculation for the previous or next UTC date if the calculated local date is not the same as the required local date.
+        /// <para>
+        /// Another wrinkle to how this method operates is that the same event can occur twice in the same day, even though this method does not provide a method to allow this to be easily obtained. For example, imagine you are located in the timezone PDT which is 4 hours behind GMT and you are calculating the times of sunset during the month of August, when PDT would be in effect. During this period, the length of the day is gradually reducing and the time of sunrise is getting earlier every day. Combined with the fact that the calculated time of Sunset for this period is around 20:00 local time or midnight UTC, you get this interesting effect where Sunrise occurs just around midnight UTC and then again just before midnight the following day!
+        /// </para>
+        /// </summary>
+        /// <param name="JD">The Julian Day corresponding to that midnight Dynamical Time for the date when you want to perform the calculation.</param>
+        /// <param name="Alpha1">The right ascension in hours of the object at time JD - 1 day</param>
+        /// <param name="Delta1">The declination in degrees of the object at time JD - 1 day</param>
+        /// <param name="Alpha2">The right ascension in hours of the object at time JD</param>
+        /// <param name="Delta2">The declination in degrees of the object at time JD</param>
+        /// <param name="Alpha3">The right ascension in hours of the object at time JD + 1 day</param>
+        /// <param name="Delta3">The declination in degrees of the object at time JD + 1 day</param>
+        /// <param name="Longitude">The geographic longitude of the observer in degrees (Positive west, negative east from Greenwich)</param>
+        /// <param name="Latitude">The geographic latitude of the observer in degrees.</param>
+        /// <param name="h0">The "standard" altitude in degrees i.e. the geometric altitude of the centre of the body at the time of the apparent rising or setting. For stars and planets, you would normally use -0.5667, for the Sun you would use -0.8333 and for the moon you would use 0.7275 * PI - 0.5666 where PI is the Moon's horizontal parallax in degrees (If no great accuracy is required, the mean value of h0 = 0.125 can be used).</param>
+        /// <returns>An instance of AASRiseTransitSetDetails class with the details.</returns>
         public static AASRiseTransitSetDetails Calculate(double JD, double Alpha1, double Delta1, double Alpha2, double Delta2, double Alpha3, double Delta3, double Longitude, double Latitude, double h0)
         {
             //What will be the return value

--- a/Src/AASharp/AASRiseTransitSetDetails.cs
+++ b/Src/AASharp/AASRiseTransitSetDetails.cs
@@ -1,13 +1,37 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASRiseTransitSet.Calculate method.
+    /// </summary>
     public class AASRiseTransitSetDetails
     {
+        /// <summary>
+        /// true if the object actually rises for the specified date.
+        /// </summary>
         public bool bRiseValid { get; set; }
+        /// <summary>
+        /// The time in decimal hours when the object rises
+        /// </summary>
         public double Rise { get; set; }
+        /// <summary>
+        /// true if the object transits for the specified date.
+        /// </summary>
         public bool bTransitValid { get; set; }
+        /// <summary>
+        /// true if the object transits above the horizon, false indicates it transits below the horizon.
+        /// </summary>
         public bool bTransitAboveHorizon { get; set; }
+        /// <summary>
+        /// The time in hours when the object transits
+        /// </summary>
         public double Transit { get; set; }
+        /// <summary>
+        /// true if the object actually sets for the specified date.
+        /// </summary>
         public bool bSetValid { get; set; }
+        /// <summary>
+        /// The time in hours when the object sets
+        /// </summary>
         public double Set { get; set; }
     }
 }

--- a/Src/AASharp/AASRiseTransitSetDetails2.cs
+++ b/Src/AASharp/AASRiseTransitSetDetails2.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// List of instances of this class are returned by AASRiseTransitSet2 class methods.
+    /// </summary>
     public class AASRiseTransitSetDetails2
     {
         public enum Type

--- a/Src/AASharp/AASSaturn.cs
+++ b/Src/AASharp/AASSaturn.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Saturn. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASSaturn
     {
         #region coefficients
@@ -709,9 +712,12 @@ namespace AASharp
             new VSOP87Coefficient( 2,   3.32,  95.98   ),
             new VSOP87Coefficient( 2,   0.56,  117.32  )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -769,6 +775,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -826,6 +835,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASSaturnMoonDetail.cs
+++ b/Src/AASharp/AASSaturnMoonDetail.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// Details of one of the following Saturn moons: Mimas, Enceladus, Tethys, Dione, Rhea, Titan, Hyperion, Iapetus.
+    /// </summary>
     public class AASSaturnMoonDetail
     {
         public AASSaturnMoonDetail()
@@ -8,11 +11,29 @@
             ApparentRectangularCoordinates = new AAS3DCoordinate();
         }
 
+        /// <summary>
+        /// The true 3D rectangular coordinates of the moon.
+        /// </summary>
         public AAS3DCoordinate TrueRectangularCoordinates { get; set; }
+        /// <summary>
+        /// The apparent 3D rectangular coordinates of the moon.
+        /// </summary>
         public AAS3DCoordinate ApparentRectangularCoordinates { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is in front of Saturn as viewed from the Earth otherwise false.
+        /// </summary>
         public bool bInTransit { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is behind Saturn as viewed from the Earth otherwise false.
+        /// </summary>
         public bool bInOccultation { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is behind Saturn as viewed from the Sun otherwise false.
+        /// </summary>
         public bool bInEclipse { get; set; }
+        /// <summary>
+        /// A Boolean which if true means that the moon is in front of Saturn as viewed from the Earth otherwise false.
+        /// </summary>
         public bool bInShadowTransit { get; set; }
     }
 }

--- a/Src/AASharp/AASSaturnMoons.cs
+++ b/Src/AASharp/AASSaturnMoons.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of positions of the principle moons of Saturn. This refers to Chapter 46 in the book.
+    /// </summary>
     public static class AASSaturnMoons
     {
         private static void HelperSubroutine(double e, double lambdadash, double p, double a, double omega, double i, double c1, double s1, ref double r, ref double lambda, ref double gamma, ref double w)
@@ -496,6 +499,9 @@ namespace AASharp
             return details;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASSaturnMoonsDetails class with the details.</returns>
         public static AASSaturnMoonsDetails Calculate(double JD, bool bHighPrecision)
         {
             //Calculate the position of the Sun

--- a/Src/AASharp/AASSaturnMoonsDetails.cs
+++ b/Src/AASharp/AASSaturnMoonsDetails.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASSaturnMoons.Calculate method.
+    /// </summary>
     public class AASSaturnMoonsDetails
     {
         public AASSaturnMoonsDetails()
@@ -14,13 +17,37 @@
             Satellite8 = new AASSaturnMoonDetail();
         }
 
+        /// <summary>
+        /// Mimas
+        /// </summary>
         public AASSaturnMoonDetail Satellite1 { get; set; }
+        /// <summary>
+        /// Enceladus
+        /// </summary>
         public AASSaturnMoonDetail Satellite2 { get; set; }
+        /// <summary>
+        /// Tethys
+        /// </summary>
         public AASSaturnMoonDetail Satellite3 { get; set; }
+        /// <summary>
+        /// Dione
+        /// </summary>
         public AASSaturnMoonDetail Satellite4 { get; set; }
+        /// <summary>
+        /// Rhea
+        /// </summary>
         public AASSaturnMoonDetail Satellite5 { get; set; }
+        /// <summary>
+        /// Titan
+        /// </summary>
         public AASSaturnMoonDetail Satellite6 { get; set; }
+        /// <summary>
+        /// Hyperion
+        /// </summary>
         public AASSaturnMoonDetail Satellite7 { get; set; }
+        /// <summary>
+        /// Iapetus
+        /// </summary>
         public AASSaturnMoonDetail Satellite8 { get; set; }
     }
 }

--- a/Src/AASharp/AASSaturnRingDetails.cs
+++ b/Src/AASharp/AASSaturnRingDetails.cs
@@ -1,14 +1,41 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by the AASSaturnRings.Calculate method.
+    /// </summary>
     public class AASSaturnRingDetails
     {
+        /// <summary>
+        /// The Saturnicentric latitude in degrees of the Earth referred to the plane of the ring.
+        /// </summary>
         public double B { get; set; }
+        /// <summary>
+        /// The Saturnicentric latitude in degrees of the Sun referred to the plane of the ring.
+        /// </summary>
         public double Bdash { get; set; }
+        /// <summary>
+        /// The geocentric position angle of the Northern semi minor axis of the apparent ellipse of the ring.
+        /// </summary>
         public double P { get; set; }
+        /// <summary>
+        /// The major axis of the outer edge of the outer ring in arc seconds.
+        /// </summary>
         public double a { get; set; }
+        /// <summary>
+        /// The minor axis of the outer edge of the outer ring in arc seconds.
+        /// </summary>
         public double b { get; set; }
+        /// <summary>
+        /// The difference in degrees between the Saturnicentric longitudes of the Sun and the Earth, measured in the plane of the ring. This quantity is required for the calculation of Saturn's magnitude.
+        /// </summary>
         public double DeltaU { get; set; }
+        /// <summary>
+        /// The Saturnicentric longitude of the Sun in degrees.
+        /// </summary>
         public double U1 { get; set; }
+        /// <summary>
+        /// The Saturnicentic longitude of the Earth in degrees.
+        /// </summary>
         public double U2 { get; set; }
     }
 }

--- a/Src/AASharp/AASSaturnRings.cs
+++ b/Src/AASharp/AASSaturnRings.cs
@@ -2,8 +2,14 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of various parameters related to the Rings of Saturn. This refers to Chapter 45 in the book.
+    /// </summary>
     public static class AASSaturnRings
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>An instance of AASSaturnRingDetails class with the details.</returns>
         public static AASSaturnRingDetails Calculate(double JD, bool bHighPrecision)
         {
             //What will be the return value

--- a/Src/AASharp/AASSelenographicMoonDetails.cs
+++ b/Src/AASharp/AASSelenographicMoonDetails.cs
@@ -1,9 +1,21 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASPhysicalMoon.CalculateSelenographicPositionOfSun method.
+    /// </summary>
     public class AASSelenographicMoonDetails
     {
+        /// <summary>
+        /// The longitude in degrees of the sub solar point.
+        /// </summary>
         public double l0 { get; set; }
+        /// <summary>
+        /// The latitude in degrees of the sub solar point.
+        /// </summary>
         public double b0 { get; set; }
+        /// <summary>
+        /// The selenographic colongitude of the sun.
+        /// </summary>
         public double c0 { get; set; }
     }
 }

--- a/Src/AASharp/AASSidereal.cs
+++ b/Src/AASharp/AASSidereal.cs
@@ -2,8 +2,13 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for the calculation of sidereal time. This refers to Chapter 12 in the book.
+    /// </summary>
     public static class AASSidereal
     {
+        /// <param name="JD">The Julian Day in Universal time to calculate for.</param>
+        /// <returns>The Mean Greenwich Sidereal Time, that is, the Greenwich hour angle of the mean vernal point (the intersection of the ecliptic of the date with the mean equator of the date), expressed in hours.</returns>
         public static double MeanGreenwichSiderealTime(double JD)
         {
             //Get the Julian day for the same day at midnight
@@ -34,6 +39,8 @@ namespace AASharp
             return AASCoordinateTransformation.MapTo0To24Range(Value);
         }
 
+        /// <param name="JD">The Julian Day in Universal time to calculate for.</param>
+        /// <returns>The Apparent Greenwich Sidereal Time, that is, the Greenwich hour angle of the true vernal equinox, expressed in hours.</returns>
         public static double ApparentGreenwichSiderealTime(double JD)
         {
             double MeanObliquity = AASNutation.MeanObliquityOfEcliptic(JD);

--- a/Src/AASharp/AASSolarEclipseDetails.cs
+++ b/Src/AASharp/AASSolarEclipseDetails.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASEclipses.CalculateSolar
+    /// </summary>
     public class AASSolarEclipseDetails
     {
         public const uint TOTAL_ECLIPSE         = 0x01;
@@ -8,12 +11,29 @@ namespace AASharp
         public const uint CENTRAL_ECLIPSE       = 0x08;
         public const uint PARTIAL_ECLIPSE       = 0x10;
         public const uint NON_CENTRAL_ECLIPSE   = 0x20;
-        
+        /// <summary>
+        /// A bitmask which indicates the type of solar eclipse which has occurred. See the constant values defined in AASSolarEclopseDetails for more information.
+        /// </summary>
         public uint Flags { get; set; }
+        /// <summary>
+        /// The date in Dynamical time of maximum eclipse.
+        /// </summary>
         public double TimeOfMaximumEclipse { get; set; }
+        /// <summary>
+        /// The moons argument of Latitude in degrees at the time of the eclipse.
+        /// </summary>
         public double F { get; set; }
+        /// <summary>
+        /// The U term for the eclipse.
+        /// </summary>
         public double u { get; set; }
+        /// <summary>
+        /// The gamma term for the eclipse.
+        /// </summary>
         public double gamma { get; set; }
+        /// <summary>
+        /// The greatest magnitude of the eclipse if the eclipse is partial.
+        /// </summary>
         public double GreatestMagnitude { get; set; }
     }
 }

--- a/Src/AASharp/AASStellarMagnitudes.cs
+++ b/Src/AASharp/AASStellarMagnitudes.cs
@@ -2,14 +2,23 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the combined magnitude of two stars. This refers to Chapter 56 in the book.
+    /// </summary>
     public static class AASStellarMagnitudes
     {
+        /// <param name="m1">The magnitude of the first star.</param>
+        /// <param name="m2">The magnitude of the second star.</param>
+        /// <returns>the combined magnitude of two stars.</returns>
         public static double CombinedMagnitude(double m1, double m2)
         {
             double x = 0.4 * (m2 - m1);
             return m2 - 2.5 * Math.Log10(Math.Pow(10.0, x) + 1);
         }
 
+        /// <param name="Magnitudes">The number of magnitudes to combine from "pMagnitudes".</param>
+        /// <param name="pMagnitudes">The sum of all the star magnitudes.</param>
+        /// <returns>the combined magnitude of more that two stars.</returns>
         public static double CombinedMagnitude(int Magnitudes, double[] pMagnitudes)
         {
             double value = 0;
@@ -19,12 +28,17 @@ namespace AASharp
             return -2.5 * Math.Log10(value);
         }
 
+        /// <param name="m1">The magnitude of the first star.</param>
+        /// <param name="m2">The magnitude of the second star.</param>
+        /// <returns>the ratio of the apparent luminosities of the two stars.</returns>
         public static double BrightnessRatio(double m1, double m2)
         {
             double x = 0.4 * (m2 - m1);
             return Math.Pow(10.0, x);
         }
 
+        /// <param name="brightnessRatio">The ratio of the apparent luminosities of the two stars.</param>
+        /// <returns>the difference in magnitude between the stars.</returns>
         public static double MagnitudeDifference(double brightnessRatio)
         {
             return 2.5 * Math.Log10(brightnessRatio);

--- a/Src/AASharp/AASSun.cs
+++ b/Src/AASharp/AASSun.cs
@@ -2,28 +2,46 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the geocentric position of the Sun. This refers to Chapter 25 &amp; 26 in the book.
+    /// </summary>
     public static class AASSun
     {
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double GeometricEclipticLongitude(double JD, bool bHighPrecision)
         {
             return AASCoordinateTransformation.MapTo0To360Range(AASEarth.EclipticLongitude(JD, bHighPrecision) + 180);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double GeometricEclipticLatitude(double JD, bool bHighPrecision)
         {
             return -AASEarth.EclipticLatitude(JD, bHighPrecision);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the J2000 equinox of the date defined in the VSOP theory.</returns>
         public static double GeometricEclipticLongitudeJ2000(double JD, bool bHighPrecision)
         {
             return AASCoordinateTransformation.MapTo0To360Range(AASEarth.EclipticLongitudeJ2000(JD, bHighPrecision) + 180);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the J2000 equinox of the date defined in the VSOP theory.</returns>
         public static double GeometricEclipticLatitudeJ2000(double JD, bool bHighPrecision)
         {
             return -AASEarth.EclipticLatitudeJ2000(JD, bHighPrecision);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the FK5 theory.</returns>
         public static double GeometricFK5EclipticLongitude(double JD, bool bHighPrecision)
         {
             //Convert to the FK5 stystem
@@ -34,6 +52,9 @@ namespace AASharp
             return Longitude;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the FK5 theory.</returns>
         public static double GeometricFK5EclipticLatitude(double JD, bool bHighPrecision)
         {
             //Convert to the FK5 stystem
@@ -45,6 +66,9 @@ namespace AASharp
             return Latitude;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the apparent ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double ApparentEclipticLongitude(double JD, bool bHighPrecision)
         {
             double Longitude = GeometricFK5EclipticLongitude(JD, bHighPrecision);
@@ -62,11 +86,17 @@ namespace AASharp
             return Longitude;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the apparent ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double ApparentEclipticLatitude(double JD, bool bHighPrecision)
         {
             return GeometricFK5EclipticLatitude(JD, bHighPrecision);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>A class containing the equatorial 3D rectangular coordinates in astronomical units referred to the mean dynamical ecliptic and equinox of the date defined in the FK5 theory.</returns>
         public static AAS3DCoordinate EquatorialRectangularCoordinatesMeanEquinox(double JD, bool bHighPrecision)
         {
             double Longitude = AASCoordinateTransformation.DegreesToRadians(GeometricFK5EclipticLongitude(JD, bHighPrecision));
@@ -84,6 +114,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>A class containing the ecliptic 3D rectangular coordinates in astronomical units referred to the J2000 equinox defined in the FK5 theory.</returns>
         public static AAS3DCoordinate EclipticRectangularCoordinatesJ2000(double JD, bool bHighPrecision)
         {
             double Longitude = GeometricEclipticLongitudeJ2000(JD, bHighPrecision);
@@ -103,7 +136,9 @@ namespace AASharp
             return value;
         }
 
-
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>A class containing the equatorial 3D rectangular coordinates in astronomical units referred to the J2000 equinox defined in the FK5 theory.</returns>
         public static AAS3DCoordinate EquatorialRectangularCoordinatesJ2000(double JD, bool bHighPrecision)
         {
             AAS3DCoordinate value = EclipticRectangularCoordinatesJ2000(JD, bHighPrecision);
@@ -112,6 +147,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>A class containing the equatorial 3D rectangular coordinates in astronomical units referred to the B1950 equinox defined in the FK5 theory.</returns>
         public static AAS3DCoordinate EquatorialRectangularCoordinatesB1950(double JD, bool bHighPrecision)
         {
             AAS3DCoordinate value = EclipticRectangularCoordinatesJ2000(JD, bHighPrecision);
@@ -120,6 +158,10 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="JDEquinox">The date in Dynamical time specifying the equinox to use.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>A class containing the equatorial 3D rectangular coordinates in astronomical units referred to the specified equinox defined in the FK5 theory.</returns>
         public static AAS3DCoordinate EquatorialRectangularCoordinatesAnyEquinox(double JD, double JDEquinox, bool bHighPrecision)
         {
             AAS3DCoordinate value = EquatorialRectangularCoordinatesJ2000(JD, bHighPrecision);
@@ -128,7 +170,9 @@ namespace AASharp
             return value;
         }
 
-        private static double VariationGeometricEclipticLongitude(double JD)
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The variation in ecliptic longitude in arcseconds per day of the Sun due to aberation.</returns>
+        public static double VariationGeometricEclipticLongitude(double JD)
         {
             //D is the number of days since the epoch
             double D = JD - 2451545.00;

--- a/Src/AASharp/AASTopocentricEclipticDetails.cs
+++ b/Src/AASharp/AASTopocentricEclipticDetails.cs
@@ -1,9 +1,21 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// An instance of this class is returned by AASParallax.Ecliptic2Topocentric method.
+    /// </summary>
     public class AASTopocentricEclipticDetails
     {
+        /// <summary>
+        /// The topocentric ecliptical longitude in degrees.
+        /// </summary>
         public double Lambda { get; set; }
+        /// <summary>
+        /// The topocentric ecliptical latitude in degrees.
+        /// </summary>
         public double Beta { get; set; }
+        /// <summary>
+        /// The topocentric semi diameter in degrees.
+        /// </summary>
         public double Semidiameter { get; set; }
     }
 }

--- a/Src/AASharp/AASUranus.cs
+++ b/Src/AASharp/AASUranus.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Uranus. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASUranus
     {
         #region coefficients
@@ -458,9 +461,12 @@ namespace AASharp
             new VSOP87Coefficient( 53, 3.01, 74.78 ),
             new VSOP87Coefficient( 10, 1.91, 56.62 )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -512,6 +518,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -562,6 +571,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASVSOP87A_EMB.cs
+++ b/Src/AASharp/AASVSOP87A_EMB.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of the Earth-Moon Barycenter for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_EMB
     {
         #region coefficients
@@ -3427,34 +3430,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z4_EMB, g_VSOP87A_Z4_EMB.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z5_EMB, g_VSOP87A_Z5_EMB.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_EMB, g_VSOP87A_X_EMB.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_EMB, g_VSOP87A_X_EMB.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_EMB, g_VSOP87A_Y_EMB.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_EMB, g_VSOP87A_Y_EMB.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_EMB, g_VSOP87A_Z_EMB.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_EMB, g_VSOP87A_Z_EMB.Length);

--- a/Src/AASharp/AASVSOP87A_Earth.cs
+++ b/Src/AASharp/AASVSOP87A_Earth.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of the Earth for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Earth
     {
         #region coefficients
@@ -3646,31 +3649,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_EARTH, g_VSOP87A_X_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_EARTH, g_VSOP87A_X_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_EARTH, g_VSOP87A_Y_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_EARTH, g_VSOP87A_Y_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_EARTH, g_VSOP87A_Z_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_EARTH, g_VSOP87A_Z_EARTH.Length);

--- a/Src/AASharp/AASVSOP87A_Jupiter.cs
+++ b/Src/AASharp/AASVSOP87A_Jupiter.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Jupiter for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Jupiter
     {
         #region coefficients
@@ -4539,34 +4542,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z4_JUPITER, g_VSOP87A_Z4_JUPITER.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z5_JUPITER, g_VSOP87A_Z5_JUPITER.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_JUPITER, g_VSOP87A_X_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_JUPITER, g_VSOP87A_X_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_JUPITER, g_VSOP87A_Y_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_JUPITER, g_VSOP87A_Y_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_JUPITER, g_VSOP87A_Z_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_JUPITER, g_VSOP87A_Z_JUPITER.Length);

--- a/Src/AASharp/AASVSOP87A_Mars.cs
+++ b/Src/AASharp/AASVSOP87A_Mars.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Mars for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Mars
     {
         #region coefficients
@@ -7178,34 +7181,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z4_MARS, g_VSOP87A_Z4_MARS.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z5_MARS, g_VSOP87A_Z5_MARS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_MARS, g_VSOP87A_X_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_MARS, g_VSOP87A_X_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_MARS, g_VSOP87A_Y_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_MARS, g_VSOP87A_Y_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_MARS, g_VSOP87A_Z_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_MARS, g_VSOP87A_Z_MARS.Length);

--- a/Src/AASharp/AASVSOP87A_Mercury.cs
+++ b/Src/AASharp/AASVSOP87A_Mercury.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Mercury for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Mercury
     {
         #region coefficients
@@ -6464,35 +6467,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z4_MERCURY, g_VSOP87A_Z4_MERCURY.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z5_MERCURY, g_VSOP87A_Z5_MERCURY.Length)
         };
-        
+
         #endregion
 
-
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_MERCURY, g_VSOP87A_X_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_MERCURY, g_VSOP87A_X_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_MERCURY, g_VSOP87A_Y_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_MERCURY, g_VSOP87A_Y_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_MERCURY, g_VSOP87A_Z_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_MERCURY, g_VSOP87A_Z_MERCURY.Length);

--- a/Src/AASharp/AASVSOP87A_Neptune.cs
+++ b/Src/AASharp/AASVSOP87A_Neptune.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Neptune for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Neptune
     {
         #region coefficients
@@ -2721,34 +2724,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z2_NEPTUNE, g_VSOP87A_Z2_NEPTUNE.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z3_NEPTUNE, g_VSOP87A_Z3_NEPTUNE.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_NEPTUNE, g_VSOP87A_X_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_NEPTUNE, g_VSOP87A_X_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_NEPTUNE, g_VSOP87A_Y_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_NEPTUNE, g_VSOP87A_Y_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_NEPTUNE, g_VSOP87A_Z_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_NEPTUNE, g_VSOP87A_Z_NEPTUNE.Length);

--- a/Src/AASharp/AASVSOP87A_Saturn.cs
+++ b/Src/AASharp/AASVSOP87A_Saturn.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Saturn for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Saturn
     {
         #region coefficients
@@ -7617,34 +7620,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z4_SATURN, g_VSOP87A_Z4_SATURN.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z5_SATURN, g_VSOP87A_Z5_SATURN.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_SATURN, g_VSOP87A_X_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_SATURN, g_VSOP87A_X_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_SATURN, g_VSOP87A_Y_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_SATURN, g_VSOP87A_Y_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_SATURN, g_VSOP87A_Z_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_SATURN, g_VSOP87A_Z_SATURN.Length);

--- a/Src/AASharp/AASVSOP87A_Uranus.cs
+++ b/Src/AASharp/AASVSOP87A_Uranus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Uranus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Uranus
     {
         #region coefficients
@@ -5376,32 +5379,44 @@
         };
 
         #endregion
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_URANUS, g_VSOP87A_X_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_URANUS, g_VSOP87A_X_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_URANUS, g_VSOP87A_Y_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_URANUS, g_VSOP87A_Y_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_URANUS, g_VSOP87A_Z_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_URANUS, g_VSOP87A_Z_URANUS.Length);

--- a/Src/AASharp/AASVSOP87A_Venus.cs
+++ b/Src/AASharp/AASVSOP87A_Venus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Venus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87A_Venus
     {
         #region coefficients
@@ -2462,34 +2465,46 @@
             new VSOP87Coefficient2(g_VSOP87A_Z4_VENUS, g_VSOP87A_Z4_VENUS.Length),
             new VSOP87Coefficient2(g_VSOP87A_Z5_VENUS, g_VSOP87A_Z5_VENUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_X_VENUS, g_VSOP87A_X_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_X_VENUS, g_VSOP87A_X_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Y_VENUS, g_VSOP87A_Y_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Y_VENUS, g_VSOP87A_Y_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87A_Z_VENUS, g_VSOP87A_Z_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87A_Z_VENUS, g_VSOP87A_Z_VENUS.Length);

--- a/Src/AASharp/AASVSOP87B_Earth.cs
+++ b/Src/AASharp/AASVSOP87B_Earth.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Earth for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Earth
     {
         #region coefficients
@@ -2672,31 +2675,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_EARTH, g_VSOP87B_L_EARTH.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_EARTH, g_VSOP87B_L_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_EARTH, g_VSOP87B_B_EARTH.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_EARTH, g_VSOP87B_B_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_EARTH, g_VSOP87B_R_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_EARTH, g_VSOP87B_R_EARTH.Length);

--- a/Src/AASharp/AASVSOP87B_Jupiter.cs
+++ b/Src/AASharp/AASVSOP87B_Jupiter.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Jupiter for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Jupiter
     {
         #region coefficients
@@ -3730,34 +3733,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R4_JUPITER, g_VSOP87B_R4_JUPITER.Length),
             new VSOP87Coefficient2(g_VSOP87B_R5_JUPITER, g_VSOP87B_R5_JUPITER.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_JUPITER, g_VSOP87B_L_JUPITER.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_JUPITER, g_VSOP87B_L_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_JUPITER, g_VSOP87B_B_JUPITER.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_JUPITER, g_VSOP87B_B_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_JUPITER, g_VSOP87B_R_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_JUPITER, g_VSOP87B_R_JUPITER.Length);

--- a/Src/AASharp/AASVSOP87B_Mars.cs
+++ b/Src/AASharp/AASVSOP87B_Mars.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Mars for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Mars
     {
         #region coefficients
@@ -6505,34 +6508,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R4_MARS, g_VSOP87B_R4_MARS.Length),
             new VSOP87Coefficient2(g_VSOP87B_R5_MARS, g_VSOP87B_R5_MARS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_MARS, g_VSOP87B_L_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_MARS, g_VSOP87B_L_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_MARS, g_VSOP87B_B_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_MARS, g_VSOP87B_B_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_MARS, g_VSOP87B_R_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_MARS, g_VSOP87B_R_MARS.Length);

--- a/Src/AASharp/AASVSOP87B_Mercury.cs
+++ b/Src/AASharp/AASVSOP87B_Mercury.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Mercury for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Mercury
     {
         #region coefficients
@@ -7228,34 +7231,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R4_MERCURY, g_VSOP87B_R4_MERCURY.Length),
             new VSOP87Coefficient2(g_VSOP87B_R5_MERCURY, g_VSOP87B_R5_MERCURY.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>The date in Dynamical time to calculate for.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_MERCURY, g_VSOP87B_L_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_MERCURY, g_VSOP87B_L_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_MERCURY, g_VSOP87B_B_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_MERCURY, g_VSOP87B_B_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_MERCURY, g_VSOP87B_R_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_MERCURY, g_VSOP87B_R_MERCURY.Length);

--- a/Src/AASharp/AASVSOP87B_Neptune.cs
+++ b/Src/AASharp/AASVSOP87B_Neptune.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Neptune for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Neptune
     {
         #region coefficients
@@ -2104,34 +2107,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R3_NEPTUNE, g_VSOP87B_R3_NEPTUNE.Length),
             new VSOP87Coefficient2(g_VSOP87B_R4_NEPTUNE, g_VSOP87B_R4_NEPTUNE.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_NEPTUNE, g_VSOP87B_L_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_NEPTUNE, g_VSOP87B_L_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_NEPTUNE, g_VSOP87B_B_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_NEPTUNE, g_VSOP87B_B_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_NEPTUNE, g_VSOP87B_R_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_NEPTUNE, g_VSOP87B_R_NEPTUNE.Length);

--- a/Src/AASharp/AASVSOP87B_Saturn.cs
+++ b/Src/AASharp/AASVSOP87B_Saturn.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Saturn for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Saturn
     {
         #region coefficients
@@ -6470,34 +6473,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R4_SATURN, g_VSOP87B_R4_SATURN.Length),
             new VSOP87Coefficient2(g_VSOP87B_R5_SATURN, g_VSOP87B_R5_SATURN.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_SATURN, g_VSOP87B_L_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_SATURN, g_VSOP87B_L_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_SATURN, g_VSOP87B_B_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_SATURN, g_VSOP87B_B_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_SATURN, g_VSOP87B_R_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_SATURN, g_VSOP87B_R_SATURN.Length);

--- a/Src/AASharp/AASVSOP87B_Uranus.cs
+++ b/Src/AASharp/AASVSOP87B_Uranus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Uranus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Uranus
     {
         #region coefficients
@@ -5354,34 +5357,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R3_URANUS, g_VSOP87B_R3_URANUS.Length),
             new VSOP87Coefficient2(g_VSOP87B_R4_URANUS, g_VSOP87B_R4_URANUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_URANUS, g_VSOP87B_L_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_URANUS, g_VSOP87B_L_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_URANUS, g_VSOP87B_B_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_URANUS, g_VSOP87B_B_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_URANUS, g_VSOP87B_R_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_URANUS, g_VSOP87B_R_URANUS.Length);

--- a/Src/AASharp/AASVSOP87B_Venus.cs
+++ b/Src/AASharp/AASVSOP87B_Venus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Venus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87B_Venus
     {
         #region coefficients
@@ -1815,34 +1818,46 @@
             new VSOP87Coefficient2(g_VSOP87B_R4_VENUS, g_VSOP87B_R4_VENUS.Length),
             new VSOP87Coefficient2(g_VSOP87B_R5_VENUS, g_VSOP87B_R5_VENUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_L_VENUS, g_VSOP87B_L_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_L_VENUS, g_VSOP87B_L_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_B_VENUS, g_VSOP87B_B_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_B_VENUS, g_VSOP87B_B_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87B_R_VENUS, g_VSOP87B_R_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87B_R_VENUS, g_VSOP87B_R_VENUS.Length);

--- a/Src/AASharp/AASVSOP87C_Earth.cs
+++ b/Src/AASharp/AASVSOP87C_Earth.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Earth for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Earth
     {
         #region coefficients
@@ -4294,34 +4297,46 @@
             new VSOP87Coefficient2(g_VSOP87C_Z3_EARTH, g_VSOP87C_Z3_EARTH.Length),
             new VSOP87Coefficient2(g_VSOP87C_Z4_EARTH, g_VSOP87C_Z4_EARTH.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_EARTH, g_VSOP87C_X_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_EARTH, g_VSOP87C_X_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_EARTH, g_VSOP87C_Y_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_EARTH, g_VSOP87C_Y_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_EARTH, g_VSOP87C_Z_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_EARTH, g_VSOP87C_Z_EARTH.Length);

--- a/Src/AASharp/AASVSOP87C_Jupiter.cs
+++ b/Src/AASharp/AASVSOP87C_Jupiter.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Jupiter for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Jupiter
     {
         #region coefficients
@@ -5660,34 +5663,46 @@
             new VSOP87Coefficient2(g_VSOP87C_Z4_JUPITER, g_VSOP87C_Z4_JUPITER.Length),
             new VSOP87Coefficient2(g_VSOP87C_Z5_JUPITER, g_VSOP87C_Z5_JUPITER.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_JUPITER, g_VSOP87C_X_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_JUPITER, g_VSOP87C_X_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_JUPITER, g_VSOP87C_Y_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_JUPITER, g_VSOP87C_Y_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_JUPITER, g_VSOP87C_Z_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_JUPITER, g_VSOP87C_Z_JUPITER.Length);

--- a/Src/AASharp/AASVSOP87C_Mars.cs
+++ b/Src/AASharp/AASVSOP87C_Mars.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Mars for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Mars
     {
         #region coefficients
@@ -8408,34 +8411,46 @@
             new VSOP87Coefficient2(g_VSOP87C_Z4_MARS, g_VSOP87C_Z4_MARS.Length),
             new VSOP87Coefficient2(g_VSOP87C_Z5_MARS, g_VSOP87C_Z5_MARS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_MARS, g_VSOP87C_X_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_MARS, g_VSOP87C_X_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_MARS, g_VSOP87C_Y_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_MARS, g_VSOP87C_Y_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_MARS, g_VSOP87C_Z_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_MARS, g_VSOP87C_Z_MARS.Length);

--- a/Src/AASharp/AASVSOP87C_Mercury.cs
+++ b/Src/AASharp/AASVSOP87C_Mercury.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Mercury for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Mercury
     {
         #region coefficients
@@ -8263,31 +8266,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_MERCURY, g_VSOP87C_X_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_MERCURY, g_VSOP87C_X_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_MERCURY, g_VSOP87C_Y_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_MERCURY, g_VSOP87C_Y_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_MERCURY, g_VSOP87C_Z_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_MERCURY, g_VSOP87C_Z_MERCURY.Length);

--- a/Src/AASharp/AASVSOP87C_Neptune.cs
+++ b/Src/AASharp/AASVSOP87C_Neptune.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Neptune for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Neptune
     {
         #region coefficients
@@ -2985,34 +2988,46 @@
             new VSOP87Coefficient2(g_VSOP87C_Z4_NEPTUNE, g_VSOP87C_Z4_NEPTUNE.Length),
             new VSOP87Coefficient2(g_VSOP87C_Z5_NEPTUNE, g_VSOP87C_Z5_NEPTUNE.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_NEPTUNE, g_VSOP87C_X_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_NEPTUNE, g_VSOP87C_X_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_NEPTUNE, g_VSOP87C_Y_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_NEPTUNE, g_VSOP87C_Y_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_NEPTUNE, g_VSOP87C_Z_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_NEPTUNE, g_VSOP87C_Z_NEPTUNE.Length);

--- a/Src/AASharp/AASVSOP87C_Saturn.cs
+++ b/Src/AASharp/AASVSOP87C_Saturn.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Saturn for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Saturn
     {
         #region coefficients
@@ -8888,34 +8891,46 @@
             new VSOP87Coefficient2(g_VSOP87C_Z4_SATURN, g_VSOP87C_Z4_SATURN.Length),
             new VSOP87Coefficient2(g_VSOP87C_Z5_SATURN, g_VSOP87C_Z5_SATURN.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_SATURN, g_VSOP87C_X_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_SATURN, g_VSOP87C_X_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_SATURN, g_VSOP87C_Y_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_SATURN, g_VSOP87C_Y_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_SATURN, g_VSOP87C_Z_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_SATURN, g_VSOP87C_Z_SATURN.Length);

--- a/Src/AASharp/AASVSOP87C_Uranus.cs
+++ b/Src/AASharp/AASVSOP87C_Uranus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Uranus for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Uranus
     {
         #region coefficients
@@ -7100,31 +7103,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_URANUS, g_VSOP87C_X_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_URANUS, g_VSOP87C_X_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_URANUS, g_VSOP87C_Y_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_URANUS, g_VSOP87C_Y_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_URANUS, g_VSOP87C_Z_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_URANUS, g_VSOP87C_Z_URANUS.Length);

--- a/Src/AASharp/AASVSOP87C_Venus.cs
+++ b/Src/AASharp/AASVSOP87C_Venus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric rectangular position of Venus for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87C_Venus
     {
         #region coefficients
@@ -3009,34 +3012,46 @@
             new VSOP87Coefficient2(g_VSOP87C_Z4_VENUS, g_VSOP87C_Z4_VENUS.Length),
             new VSOP87Coefficient2(g_VSOP87C_Z5_VENUS, g_VSOP87C_Z5_VENUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_X_VENUS, g_VSOP87C_X_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_X_VENUS, g_VSOP87C_X_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Y_VENUS, g_VSOP87C_Y_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Y_VENUS, g_VSOP87C_Y_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87C_Z_VENUS, g_VSOP87C_Z_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87C_Z_VENUS, g_VSOP87C_Z_VENUS.Length);

--- a/Src/AASharp/AASVSOP87D_Earth.cs
+++ b/Src/AASharp/AASVSOP87D_Earth.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Earth for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Earth
     {
         #region coefficients
@@ -2525,34 +2528,46 @@
             new VSOP87Coefficient2(g_VSOP87D_R4_EARTH, g_VSOP87D_R4_EARTH.Length),
             new VSOP87Coefficient2(g_VSOP87D_R5_EARTH, g_VSOP87D_R5_EARTH.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_EARTH, g_VSOP87D_L_EARTH.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_EARTH, g_VSOP87D_L_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_EARTH, g_VSOP87D_B_EARTH.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_EARTH, g_VSOP87D_B_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_EARTH, g_VSOP87D_R_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_EARTH, g_VSOP87D_R_EARTH.Length);

--- a/Src/AASharp/AASVSOP87D_Jupiter.cs
+++ b/Src/AASharp/AASVSOP87D_Jupiter.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Jupiter for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Jupiter
     {
         #region coefficients
@@ -3588,34 +3591,46 @@
             new VSOP87Coefficient2(g_VSOP87D_R4_JUPITER, g_VSOP87D_R4_JUPITER.Length),
             new VSOP87Coefficient2(g_VSOP87D_R5_JUPITER, g_VSOP87D_R5_JUPITER.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_JUPITER, g_VSOP87D_L_JUPITER.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_JUPITER, g_VSOP87D_L_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_JUPITER, g_VSOP87D_B_JUPITER.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_JUPITER, g_VSOP87D_B_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_JUPITER, g_VSOP87D_R_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_JUPITER, g_VSOP87D_R_JUPITER.Length);

--- a/Src/AASharp/AASVSOP87D_Mars.cs
+++ b/Src/AASharp/AASVSOP87D_Mars.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Mars for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Mars
     {
         #region coefficients
@@ -5588,34 +5591,46 @@
             new VSOP87Coefficient2(g_VSOP87D_R4_MARS, g_VSOP87D_R4_MARS.Length),
             new VSOP87Coefficient2(g_VSOP87D_R5_MARS, g_VSOP87D_R5_MARS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_MARS, g_VSOP87D_L_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_MARS, g_VSOP87D_L_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_MARS, g_VSOP87D_B_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_MARS, g_VSOP87D_B_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_MARS, g_VSOP87D_R_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_MARS, g_VSOP87D_R_MARS.Length);

--- a/Src/AASharp/AASVSOP87D_Mercury.cs
+++ b/Src/AASharp/AASVSOP87D_Mercury.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Mercury for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Mercury
     {
         #region coefficients
@@ -6935,31 +6938,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_MERCURY, g_VSOP87D_L_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_MERCURY, g_VSOP87D_L_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_MERCURY, g_VSOP87D_B_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_MERCURY, g_VSOP87D_B_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_MERCURY, g_VSOP87D_R_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_MERCURY, g_VSOP87D_R_MERCURY.Length);

--- a/Src/AASharp/AASVSOP87D_Neptune.cs
+++ b/Src/AASharp/AASVSOP87D_Neptune.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Neptune for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Neptune
     {
         #region coefficients
@@ -2032,31 +2035,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_NEPTUNE, g_VSOP87D_L_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_NEPTUNE, g_VSOP87D_L_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_NEPTUNE, g_VSOP87D_B_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_NEPTUNE, g_VSOP87D_B_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_NEPTUNE, g_VSOP87D_R_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_NEPTUNE, g_VSOP87D_R_NEPTUNE.Length);

--- a/Src/AASharp/AASVSOP87D_Saturn.cs
+++ b/Src/AASharp/AASVSOP87D_Saturn.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Saturn for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Saturn
     {
         #region coefficients
@@ -5864,34 +5867,46 @@
             new VSOP87Coefficient2(g_VSOP87D_R4_SATURN, g_VSOP87D_R4_SATURN.Length),
             new VSOP87Coefficient2(g_VSOP87D_R5_SATURN, g_VSOP87D_R5_SATURN.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_SATURN, g_VSOP87D_L_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_SATURN, g_VSOP87D_L_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_SATURN, g_VSOP87D_B_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_SATURN, g_VSOP87D_B_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_SATURN, g_VSOP87D_R_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_SATURN, g_VSOP87D_R_SATURN.Length);

--- a/Src/AASharp/AASVSOP87D_Uranus.cs
+++ b/Src/AASharp/AASVSOP87D_Uranus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Uranus for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Uranus
     {
         #region coefficients
@@ -4084,34 +4087,46 @@
             new VSOP87Coefficient2(g_VSOP87D_R3_URANUS, g_VSOP87D_R3_URANUS.Length),
             new VSOP87Coefficient2(g_VSOP87D_R4_URANUS, g_VSOP87D_R4_URANUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_URANUS, g_VSOP87D_L_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_URANUS, g_VSOP87D_L_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_URANUS, g_VSOP87D_B_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_URANUS, g_VSOP87D_B_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_URANUS, g_VSOP87D_R_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_URANUS, g_VSOP87D_R_URANUS.Length);

--- a/Src/AASharp/AASVSOP87D_Venus.cs
+++ b/Src/AASharp/AASVSOP87D_Venus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric spherical position of Venus for the equinox and ecliptic of date. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87D_Venus
     {
         #region coefficients
@@ -1790,31 +1793,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_L_VENUS, g_VSOP87D_L_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic longitude in radians / day.</returns>
         public static double L_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_L_VENUS, g_VSOP87D_L_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the ecliptic latitude in radians.</returns>
         public static double B(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_B_VENUS, g_VSOP87D_B_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the ecliptic latitude in radians / day.</returns>
         public static double B_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_B_VENUS, g_VSOP87D_B_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double R(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87D_R_VENUS, g_VSOP87D_R_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the radius vector in astronomical units / day.</returns>
         public static double R_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87D_R_VENUS, g_VSOP87D_R_VENUS.Length);

--- a/Src/AASharp/AASVSOP87E_Earth.cs
+++ b/Src/AASharp/AASVSOP87E_Earth.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Earth for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Earth
     {
         #region coefficients
@@ -5661,34 +5664,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z4_EARTH, g_VSOP87E_Z4_EARTH.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z5_EARTH, g_VSOP87E_Z5_EARTH.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_EARTH, g_VSOP87E_X_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_EARTH, g_VSOP87E_X_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_EARTH, g_VSOP87E_Y_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_EARTH, g_VSOP87E_Y_EARTH.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_EARTH, g_VSOP87E_Z_EARTH.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_EARTH, g_VSOP87E_Z_EARTH.Length);

--- a/Src/AASharp/AASVSOP87E_Jupiter.cs
+++ b/Src/AASharp/AASVSOP87E_Jupiter.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Jupiter for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Jupiter
     {
         #region coefficients
@@ -4647,34 +4650,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z4_JUPITER, g_VSOP87E_Z4_JUPITER.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z5_JUPITER, g_VSOP87E_Z5_JUPITER.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_JUPITER, g_VSOP87E_X_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_JUPITER, g_VSOP87E_X_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_JUPITER, g_VSOP87E_Y_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_JUPITER, g_VSOP87E_Y_JUPITER.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_JUPITER, g_VSOP87E_Z_JUPITER.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_JUPITER, g_VSOP87E_Z_JUPITER.Length);

--- a/Src/AASharp/AASVSOP87E_Mars.cs
+++ b/Src/AASharp/AASVSOP87E_Mars.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Mars for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Mars
     {
         #region coefficients
@@ -7680,35 +7683,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z4_MARS, g_VSOP87E_Z4_MARS.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z5_MARS, g_VSOP87E_Z5_MARS.Length)
         };
-        
+
         #endregion
 
-
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_MARS, g_VSOP87E_X_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_MARS, g_VSOP87E_X_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_MARS, g_VSOP87E_Y_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_MARS, g_VSOP87E_Y_MARS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_MARS, g_VSOP87E_Z_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_MARS, g_VSOP87E_Z_MARS.Length);

--- a/Src/AASharp/AASVSOP87E_Mercury.cs
+++ b/Src/AASharp/AASVSOP87E_Mercury.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Mercury for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Mercury
     {
         #region coefficients
@@ -7985,34 +7988,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z4_MERCURY, g_VSOP87E_Z4_MERCURY.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z5_MERCURY, g_VSOP87E_Z5_MERCURY.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_MERCURY, g_VSOP87E_X_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_MERCURY, g_VSOP87E_X_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_MERCURY, g_VSOP87E_Y_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_MERCURY, g_VSOP87E_Y_MERCURY.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_MERCURY, g_VSOP87E_Z_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_MERCURY, g_VSOP87E_Z_MERCURY.Length);

--- a/Src/AASharp/AASVSOP87E_Neptune.cs
+++ b/Src/AASharp/AASVSOP87E_Neptune.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Neptune for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Neptune
     {
         #region coefficients
@@ -2474,34 +2477,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z2_NEPTUNE, g_VSOP87E_Z2_NEPTUNE.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z3_NEPTUNE, g_VSOP87E_Z3_NEPTUNE.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_NEPTUNE, g_VSOP87E_X_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_NEPTUNE, g_VSOP87E_X_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_NEPTUNE, g_VSOP87E_Y_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_NEPTUNE, g_VSOP87E_Y_NEPTUNE.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_NEPTUNE, g_VSOP87E_Z_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_NEPTUNE, g_VSOP87E_Z_NEPTUNE.Length);

--- a/Src/AASharp/AASVSOP87E_Saturn.cs
+++ b/Src/AASharp/AASVSOP87E_Saturn.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Saturn for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Saturn
     {
         #region coefficients
@@ -7630,31 +7633,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_SATURN, g_VSOP87E_X_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_SATURN, g_VSOP87E_X_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_SATURN, g_VSOP87E_Y_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_SATURN, g_VSOP87E_Y_SATURN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_SATURN, g_VSOP87E_Z_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_SATURN, g_VSOP87E_Z_SATURN.Length);

--- a/Src/AASharp/AASVSOP87E_Sun.cs
+++ b/Src/AASharp/AASVSOP87E_Sun.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of the Sun for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Sun
     {
         #region coefficients
@@ -6739,34 +6742,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z4_SUN, g_VSOP87E_Z4_SUN.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z5_SUN, g_VSOP87E_Z5_SUN.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_SUN, g_VSOP87E_X_SUN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_SUN, g_VSOP87E_X_SUN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_SUN, g_VSOP87E_Y_SUN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_SUN, g_VSOP87E_Y_SUN.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_SUN, g_VSOP87E_Z_SUN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_SUN, g_VSOP87E_Z_SUN.Length);

--- a/Src/AASharp/AASVSOP87E_Uranus.cs
+++ b/Src/AASharp/AASVSOP87E_Uranus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Uranus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Uranus
     {
         #region coefficients
@@ -5210,34 +5213,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z2_URANUS, g_VSOP87E_Z2_URANUS.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z3_URANUS, g_VSOP87E_Z3_URANUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_URANUS, g_VSOP87E_X_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_URANUS, g_VSOP87E_X_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_URANUS, g_VSOP87E_Y_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_URANUS, g_VSOP87E_Y_URANUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_URANUS, g_VSOP87E_Z_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_URANUS, g_VSOP87E_Z_URANUS.Length);

--- a/Src/AASharp/AASVSOP87E_Venus.cs
+++ b/Src/AASharp/AASVSOP87E_Venus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the barycentric rectangular position of Venus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87E_Venus
     {
         #region coefficients
@@ -4762,34 +4765,46 @@
             new VSOP87Coefficient2(g_VSOP87E_Z4_VENUS, g_VSOP87E_Z4_VENUS.Length),
             new VSOP87Coefficient2(g_VSOP87E_Z5_VENUS, g_VSOP87E_Z5_VENUS.Length)
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the X position component in astronomical units.</returns>
         public static double X(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_X_VENUS, g_VSOP87E_X_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the X position component in astronomical units / day.</returns>
         public static double X_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_X_VENUS, g_VSOP87E_X_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Y position component in astronomical units.</returns>
         public static double Y(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Y_VENUS, g_VSOP87E_Y_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Y position component in astronomical units / day.</returns>
         public static double Y_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Y_VENUS, g_VSOP87E_Y_VENUS.Length);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Z position component in astronomical units.</returns>
         public static double Z(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87E_Z_VENUS, g_VSOP87E_Z_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the rate of change of the Z position component in astronomical units / day.</returns>
         public static double Z_DASH(double JD)
         {
             return CVSOP87.Calculate_Dash(JD, g_VSOP87E_Z_VENUS, g_VSOP87E_Z_VENUS.Length);

--- a/Src/AASharp/AASVSOP87_EMB.cs
+++ b/Src/AASharp/AASVSOP87_EMB.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of the Earth-Moon Barycenter for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_EMB
     {
         #region coefficients
@@ -4392,35 +4395,46 @@
             new VSOP87Coefficient2(g_VSOP87_P4_EMB, g_VSOP87_P4_EMB.Length),
             new VSOP87Coefficient2(g_VSOP87_P5_EMB, g_VSOP87_P5_EMB.Length)
         };
-    
+
         #endregion
-    
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
           return CVSOP87.Calculate(JD, g_VSOP87_A_EMB, g_VSOP87_A_EMB.Length, false);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
           return CVSOP87.Calculate(JD, g_VSOP87_L_EMB, g_VSOP87_L_EMB.Length, true);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
           return CVSOP87.Calculate(JD, g_VSOP87_K_EMB, g_VSOP87_K_EMB.Length, true);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
           return CVSOP87.Calculate(JD, g_VSOP87_H_EMB, g_VSOP87_H_EMB.Length, true);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
           return CVSOP87.Calculate(JD, g_VSOP87_Q_EMB, g_VSOP87_Q_EMB.Length, true);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
           return CVSOP87.Calculate(JD, g_VSOP87_P_EMB, g_VSOP87_P_EMB.Length, true);

--- a/Src/AASharp/AASVSOP87_Jupiter.cs
+++ b/Src/AASharp/AASVSOP87_Jupiter.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Jupiter for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Jupiter {
 
         #region coefficients
@@ -6256,34 +6259,46 @@
             new VSOP87Coefficient2(g_VSOP87_P2_JUPITER, g_VSOP87_P2_JUPITER.Length),
             new VSOP87Coefficient2(g_VSOP87_P3_JUPITER, g_VSOP87_P3_JUPITER.Length)
         };
-    
+
         #endregion
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_JUPITER, g_VSOP87_A_JUPITER.Length, false);
         }
-    
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_JUPITER, g_VSOP87_L_JUPITER.Length, true);
         }
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_JUPITER, g_VSOP87_K_JUPITER.Length, true);
         }
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_JUPITER, g_VSOP87_H_JUPITER.Length, true);
         }
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_JUPITER, g_VSOP87_Q_JUPITER.Length, true);
         }
-        
+
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_JUPITER, g_VSOP87_P_JUPITER.Length, true);

--- a/Src/AASharp/AASVSOP87_Mars.cs
+++ b/Src/AASharp/AASVSOP87_Mars.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Mars for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Mars
     {
         #region coefficients
@@ -7698,31 +7701,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_MARS, g_VSOP87_A_MARS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_MARS, g_VSOP87_L_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_MARS, g_VSOP87_K_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_MARS, g_VSOP87_H_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_MARS, g_VSOP87_Q_MARS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_MARS, g_VSOP87_P_MARS.Length, true);

--- a/Src/AASharp/AASVSOP87_Mercury.cs
+++ b/Src/AASharp/AASVSOP87_Mercury.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Mercury for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Mercury
     {
         #region coefficients
@@ -4997,31 +5000,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_MERCURY, g_VSOP87_A_MERCURY.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_MERCURY, g_VSOP87_L_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_MERCURY, g_VSOP87_K_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_MERCURY, g_VSOP87_H_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_MERCURY, g_VSOP87_Q_MERCURY.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_MERCURY, g_VSOP87_P_MERCURY.Length, true);

--- a/Src/AASharp/AASVSOP87_Neptune.cs
+++ b/Src/AASharp/AASVSOP87_Neptune.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Neptune for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Neptune
     {
         #region coefficients
@@ -8207,31 +8210,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_NEPTUNE, g_VSOP87_A_NEPTUNE.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_NEPTUNE, g_VSOP87_L_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_NEPTUNE, g_VSOP87_K_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_NEPTUNE, g_VSOP87_H_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_NEPTUNE, g_VSOP87_Q_NEPTUNE.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_NEPTUNE, g_VSOP87_P_NEPTUNE.Length, true);

--- a/Src/AASharp/AASVSOP87_Saturn.cs
+++ b/Src/AASharp/AASVSOP87_Saturn.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Saturn for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Saturn
     {
         #region coefficients
@@ -12541,32 +12544,43 @@
 
         #endregion
 
-
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_SATURN, g_VSOP87_A_SATURN.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_SATURN, g_VSOP87_L_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_SATURN, g_VSOP87_K_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_SATURN, g_VSOP87_H_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_SATURN, g_VSOP87_Q_SATURN.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_SATURN, g_VSOP87_P_SATURN.Length, true);

--- a/Src/AASharp/AASVSOP87_Uranus.cs
+++ b/Src/AASharp/AASVSOP87_Uranus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Uranus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Uranus
     {
         #region coefficients
@@ -15362,32 +15365,43 @@
 
         #endregion
 
-
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_URANUS, g_VSOP87_A_URANUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_URANUS, g_VSOP87_L_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_URANUS, g_VSOP87_K_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_URANUS, g_VSOP87_H_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_URANUS, g_VSOP87_Q_URANUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_URANUS, g_VSOP87_P_URANUS.Length, true);

--- a/Src/AASharp/AASVSOP87_Venus.cs
+++ b/Src/AASharp/AASVSOP87_Venus.cs
@@ -1,5 +1,8 @@
 ﻿namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric ecliptical orbital elements of Venus for the equinox and ecliptic of J2000.0. Please refer to ftp://cdsarc.u-strasbg.fr/pub/cats/VI/81/ for further details.
+    /// </summary>
     public class AASVSOP87_Venus
     {
         #region coefficients
@@ -3172,31 +3175,43 @@
 
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the semi-major axis in astronomical units.</returns>
         public static double A(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_A_VENUS, g_VSOP87_A_VENUS.Length, false);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the mean longitude in radians.</returns>
         public static double L(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_L_VENUS, g_VSOP87_L_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the K value as defined in VSOP87 i.e. k = e cos(p) where p is the perihelion longitude.</returns>
         public static double K(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_K_VENUS, g_VSOP87_K_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the H value as defined in VSOP87 i.e. h = e sin(p) where p is the perihelion longitude.</returns>
         public static double H(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_H_VENUS, g_VSOP87_H_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the Q value as defined in VSOP87 i.e. q = sin(g) cos(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double Q(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_Q_VENUS, g_VSOP87_Q_VENUS.Length, true);
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <returns>the P value as defined in VSOP87 i.e. p = sin(g) sin(G) where g is the semi-inclination and G is the ascending node longitude.</returns>
         public static double P(double JD)
         {
             return CVSOP87.Calculate(JD, g_VSOP87_P_VENUS, g_VSOP87_P_VENUS.Length, true);

--- a/Src/AASharp/AASVenus.cs
+++ b/Src/AASharp/AASVenus.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace AASharp
 {
+    /// <summary>
+    /// This class provides for calculation of the heliocentric position of Venus. This refers to Chapter 32 in the book.
+    /// </summary>
     public static class AASVenus
     {
         #region coefficient
@@ -162,9 +165,12 @@ namespace AASharp
         { 
             new VSOP87Coefficient( 1, 0.92, 10213.29 )
         };
-        
+
         #endregion
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic longitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLongitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -222,6 +228,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the ecliptic latitude in degrees referred to the mean dynamical ecliptic and equinox of the date defined in the VSOP theory.</returns>
         public static double EclipticLatitude(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)
@@ -272,6 +281,9 @@ namespace AASharp
             return value;
         }
 
+        /// <param name="JD">The date in Dynamical time to calculate for.</param>
+        /// <param name="bHighPrecision">If true then use the full VSOP87 theory instead of the truncated version as provided in Meeus's book.</param>
+        /// <returns>the radius vector in astronomical units.</returns>
         public static double RadiusVector(double JD, bool bHighPrecision)
         {
             if (bHighPrecision)

--- a/Src/AASharp/AASharp.csproj
+++ b/Src/AASharp/AASharp.csproj
@@ -19,6 +19,7 @@ AASharp is a C# port of PJ Naughter's static C++ library, AA+. Naughter's librar
     <PackageReleaseNotes>https://github.com/jsauve/AASharp/releases</PackageReleaseNotes>
     <PackageLicenseUrl>https://github.com/jsauve/AASharp/blob/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/Src/AASharp/EventType.cs
+++ b/Src/AASharp/EventType.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Used by the AASPlanetaryPhenomena class methods.
+    /// </summary>
     public enum EventType
     {
         INFERIOR_CONJUNCTION,

--- a/Src/AASharp/PlanetaryObject.cs
+++ b/Src/AASharp/PlanetaryObject.cs
@@ -1,5 +1,8 @@
 namespace AASharp
 {
+    /// <summary>
+    /// Used by the AASPlanetaryPhenomena class methods.
+    /// </summary>
     public enum PlanetaryObject
     {
         MERCURY,


### PR DESCRIPTION
Hi @jsauve @elendil-software 

I took the [AA+ package](http://www.naughter.com/download/aaplus.zip), unzipped and opened **AA+.htm** document in the browser. The document has a **Class Framework Reference** section where all the AA+ classes are documented. Using this source  I created an [XML documentation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/) which could be very handful during coding because almost all the AASharp classes and methods are now self documented.
